### PR TITLE
docs: sync README + add docs-sync CI gate + queue next specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,41 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --all-targets
       - run: cargo test --workspace --doc
+
+  docs-sync:
+    # Block PRs where Rust source under crates/ changes but no documentation
+    # file is touched. Catches implementation drift against README / CHANGELOG
+    # / docs/. Escape hatch: include `[skip-docs]` in the PR title or body.
+    # Runs only on pull_request (not push), because main has no upstream to
+    # diff against.
+    name: docs-sync
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for doc updates alongside code changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          if [[ "$PR_TITLE$PR_BODY" == *"[skip-docs]"* ]]; then
+            echo "::notice::[skip-docs] escape hatch present in PR title/body — bypassing docs-sync check"
+            exit 0
+          fi
+          changed="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          echo "Changed files:"
+          echo "$changed"
+          code_changed="$(echo "$changed" | grep -E '^crates/.+\.rs$' || true)"
+          docs_changed="$(echo "$changed" | grep -E '^(README\.md|CHANGELOG\.md|CONTRIBUTING\.md|docs/.+\.md|specs/.+\.md)$' || true)"
+          if [[ -n "$code_changed" && -z "$docs_changed" ]]; then
+            echo "::error::Rust source in crates/ changed but no documentation file was updated."
+            echo "Touch one of: README.md, CHANGELOG.md, CONTRIBUTING.md, docs/**/*.md, or specs/**/*.md."
+            echo "If the change genuinely needs no documentation (refactor, rename, CI fix), add '[skip-docs]' to the PR title or body."
+            exit 1
+          fi
+          echo "::notice::docs-sync OK"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to SpecERE will be documented here. The format follows [Keep
 
 ## [Unreleased]
 
+### Added (post-Phase-1)
+- `docs/upcoming.md` — lightweight priority queue of the next specs (release-infra, Phase 2 native units, Phase 3 observe pipeline) with carry-over items from `.specere/decisions.log`.
+- `docs-sync` CI job in `.github/workflows/ci.yml`. Blocks PRs where `crates/**/*.rs` changes without any `README.md` / `CHANGELOG.md` / `CONTRIBUTING.md` / `docs/**/*.md` / `specs/**/*.md` touch. Escape hatch: include `[skip-docs]` in the PR title or body.
+
+### Changed
+- `README.md` Status table corrected: Phase 0 marked ✅ Shipped, Phase 1 marked ✅ Merged (PR #2, 9 FRs, 37/37 CI tests green). Reflects `main @ ae7b4c4` state.
+
 ### Added
 - Initial Rust workspace skeleton: `specere`, `specere-core`, `specere-units`, `specere-manifest`, `specere-markers`, `specere-telemetry`.
 - CLI surface stubs: `add`, `remove`, `status`, `verify`, `doctor`, `observe`, `version`.

--- a/README.md
+++ b/README.md
@@ -32,20 +32,20 @@ This uninstall-first design is SpecERE's core UX differentiator versus SpecKit, 
 
 ## Status
 
-**Pre-0.1.0.** Under active development per the [v1.0 plan](docs/specere_v1.md). Not yet on crates.io.
+**Pre-0.1.0 release** — `0.2.0-dev` on `main`. Phase 1 merged; v0.2.0 tag not yet cut (release infrastructure is the next spec). Not yet on crates.io.
 
 | Phase | What ships | Status |
 |---|---|---|
-| Phase 0 — doc rectification       | README / CONTRIBUTING / CHANGELOG aligned to pivot           | 🚧 In progress |
-| Phase 1 — bugfix release `v0.2.0` | Drop `--no-git`, SHA-diff gate, first `after_implement` hook | ⏳ Next |
-| Phase 2 — native units            | All 5 MVP units implemented end-to-end                       | ⏳ Planned |
+| Phase 0 — doc rectification       | README / CONTRIBUTING / CHANGELOG aligned to pivot           | ✅ Shipped (2026-04-18) |
+| Phase 1 — bugfix release `v0.2.0` | Drop `--no-git`, SHA-diff gate, first `after_implement` hook, marker-fenced `.gitignore`, bit-identical remove, parse-safety | ✅ Merged (PR #2, 2026-04-18) — 9 FRs, 37/37 tests green on Linux/macOS/Windows; v0.2.0 tag pending release-infra |
+| Phase 2 — native units            | All 5 MVP units implemented end-to-end                       | ⏳ Next (see [`docs/upcoming.md`](docs/upcoming.md)) |
 | Phase 3 — observe pipeline        | Embedded OTLP receiver + `specere-observe` workflow          | ⏳ Planned |
 | Phase 4 — filter engine           | Rust port of the ReSearch prototype's three Bayesian filters | ⏳ Planned |
 | Phase 5 — motion-model calibration| `specere calibrate from-git`                                 | ⏳ Planned |
 | Phase 6 — cross-session persistence | Posterior survives across sessions                         | ⏳ Planned |
 | Phase 7 — v1.0.0 release          | Final tear-down-and-rebuild dogfood on ReSearch              | ⏳ Planned |
 
-See [CHANGELOG.md](./CHANGELOG.md) for release notes and [`docs/specere_v1.md`](docs/specere_v1.md) for the 36-FR / 7-SC master plan.
+See [`CHANGELOG.md`](./CHANGELOG.md) for release notes, [`docs/specere_v1.md`](docs/specere_v1.md) for the 36-FR / 7-SC master plan, and [`docs/upcoming.md`](docs/upcoming.md) for the queued-next specs.
 
 ## Design documents
 

--- a/docs/upcoming.md
+++ b/docs/upcoming.md
@@ -1,0 +1,44 @@
+# Upcoming specs — the SpecERE work queue
+
+> **Purpose.** Lightweight running list of the next feature specs in priority order. Updated when a spec lands, when a phase closes, or when a divergence-adjudication decision queues new work.
+>
+> Each entry points at the [`docs/specere_v1.md`](specere_v1.md) phase it implements, plus any carry-over items from prior `.specere/decisions.log` entries.
+
+## Priority queue (highest first)
+
+### 1. `release-infra` — cut v0.2.0 (blocks the Phase 1 release tag)
+
+- **Why it's first.** Phase 1 is merged on `main` at `ae7b4c4`, but the workspace is still version-pinned as `0.2.0-dev`. No v0.2.0 tag has been cut because `cargo-dist` + `.github/workflows/release.yml` are not wired (the master plan's "cargo-dist is already configured" assumption is stale — verified 2026-04-18 post-PR-#2).
+- **Deliverables.**
+  - Add `.github/workflows/release.yml` driven by `cargo-dist` (tag trigger → cross-platform binaries → GitHub Release assets).
+  - Add `[workspace.metadata.dist]` in `Cargo.toml` with the four target triples from `docs/roadmap/31_specere_scaffolding.md §2`.
+  - Bump workspace version `0.2.0-dev → 0.2.0`; move CHANGELOG `[0.2.0-dev]` → `[0.2.0] — 2026-MM-DD`.
+  - Tag `v0.2.0` on the release-infra merge commit.
+- **Scope guard.** Pure release plumbing. No FR changes, no crate surface changes.
+- **Phase mapping.** Closes out Phase 1 (docs/specere_v1.md §5.P1) — the plan listed cargo-dist as an implicit prereq; this spec makes it explicit.
+
+### 2. `phase-2-native-units` — finish the 5 MVP units
+
+- **Why it's next.** Per `docs/specere_v1.md §5 Phase 2`, five units ship end-to-end before Phase 3's observe pipeline has anything to plug into.
+- **Deliverables.**
+  - Promote `filter-state`, `otel-collector`, `ears-linter` from stub to real implementations (currently `stub::StubUnit` in `crates/specere-units/src/lib.rs`).
+  - Extend `claude-code-deploy` with `specere-observe-implement` / `specere-review-check` / `specere-review-drain` skills registered under the right slash-command surface (these skills' `SKILL.md` files are already bundled; missing piece is `specere init`-time activation).
+  - `specere init` meta-command that composes all five units idempotently, per Phase 2 FR-P2-005.
+- **Carry-over from v0.2.0 review-queue drain** (`.specere/decisions.log` entry 2026-04-18): `speckit::preflight` orphan detector. The wrapper unit should detect stale `.specify/feature.json` / ghost feature-branch dirs (produced when `specify workflow run` spawns `claude -p` and that subprocess is killed mid-run). Folds into the `speckit` section of the Phase 2 spec.
+- **Phase mapping.** `docs/specere_v1.md §5.P2` (FR-P2-001 … FR-P2-007).
+
+### 3. `phase-3-observe-pipeline` — `specere serve` + persisted events
+
+- **Why it's third.** Builds on Phase 2's `otel-collector` unit to stand up a real embedded OTLP receiver.
+- **Deliverables.** `crates/specere-telemetry` gains a `tonic` gRPC server on `localhost:4317`, an `axum` HTTP server on `:4318`, SQLite + JSONL event store, `specere serve` + `specere observe record` + `specere observe query` commands, and the `specere-observe` workflow's OTel-span-around-each-step wrapping.
+- **Phase mapping.** `docs/specere_v1.md §5.P3` (FR-P3-001 … FR-P3-006).
+
+## Beyond the immediate queue
+
+Phases 4–7 (filter engine, motion-model calibration, cross-session persistence, v1.0.0 dogfood) remain as in the master plan. They are not queued here because Phases 2 and 3 gate them.
+
+## Queue hygiene
+
+- **Adding.** When a spec surfaces a follow-up (e.g. a review-queue EXTEND decision), add it to the priority-queue section with a one-line link back to its origin (spec id, FR, or decisions.log timestamp).
+- **Closing.** When a queued spec lands on `main`, delete its entry here; the CHANGELOG + the phase table in [`README.md`](../README.md) become the authoritative records.
+- **Priority.** Reorder only when a real dependency changes. Don't reshuffle on vibes.


### PR DESCRIPTION
## Summary

- **README Status table** corrected: was stale since PR #2 merged on 2026-04-18. Phase 0 → ✅ Shipped. Phase 1 → ✅ Merged (9 FRs, 37/37 CI green). Links to new `docs/upcoming.md` for the queued-next specs.
- **New `docs-sync` CI job**: blocks PRs where `crates/**/*.rs` changes without any doc update (README / CHANGELOG / CONTRIBUTING / docs / specs). Escape hatch: `[skip-docs]` in the PR title or body for pure refactor / rename / CI-only changes. Runs only on `pull_request` (not push-to-main, which has no upstream to diff against).
- **`docs/upcoming.md`** — lightweight priority queue of the next specs:
  1. `release-infra`: wire `cargo-dist` + `.github/workflows/release.yml`, then bump version and cut `v0.2.0`.
  2. `phase-2-native-units`: promote `filter-state` / `otel-collector` / `ears-linter` from stubs; includes the `speckit::preflight` orphan-detector carry-over from 2026-04-18's `.specere/decisions.log` EXTEND.
  3. `phase-3-observe-pipeline`: `specere serve` + embedded OTLP receiver + SQLite event store.

## Why

User-reported drift: `main` advanced across PR #2 (~4000 LoC, 9 FRs, new CI-green matrix), but `README.md`'s Status table still said "Phase 0: 🚧 In progress / Phase 1: ⏳ Next". The `docs-sync` check makes this kind of drift a blocking CI failure, not a post-hoc chore.

## Test plan

- [ ] CI's own new `docs-sync` job passes on this PR (README + CHANGELOG + docs/ all touched alongside the CI config change — the check is self-satisfying here).
- [ ] `rustfmt` / `clippy` / `test (ubuntu|macos|windows)` stay green (no Rust source changed).
- [ ] After merge, next PR that touches `crates/**/*.rs` without a doc update is blocked by the new job.
- [ ] `[skip-docs]` escape hatch works: a PR with it in the title bypasses the check.

## Post-merge

`docs/upcoming.md` is now the canonical queue. Next session opens the `release-infra` spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)