### PR TITLE
feat(harness): subagents + CLAUDE.md rules + issue-driven contributing doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to SpecERE will be documented here. The format follows [Keep
 
 ## [Unreleased]
 
+### Added
+- `AgentBundle` in `crates/specere-units/src/deploy/mod.rs` alongside the existing `SkillBundle`. `Deploy` trait gains `agents()` + `agent_dir()` + `agent_rel_path()` with sensible defaults. Issue #7.
+- First SpecERE subagent shipped via `claude-code-deploy`: `specere-reviewer` at `.claude/agents/specere-reviewer.md`, a constitution-compliant PR/diff reviewer. Matches the CI `review` job's prompt but usable interactively via the `Agent` tool. Issue #7.
+- Second marker-fenced block in `CLAUDE.md`: `rules`. Contains the 10 composition rules + NEVER-do list, session-durable so every agent invocation sees them up-front (not only on-demand via skills). Sourced from `crates/specere-units/src/deploy/rules/specere-rules.md`. Issue #8.
+- `docs/contributing-via-issues.md` — canonical bug/flaw/feature → parent issue → sub-issues → PR pipeline. Linked from `CONTRIBUTING.md`. Issue #9.
+
+### Changed
+- `claude-code-deploy`'s install record now lists an additional `MarkerEntry` for `CLAUDE.md` block `rules`, and an agent `FileEntry` under `.claude/agents/`. `remove` inverts both cleanly (byte-identical round-trip per FR-P1-006).
+- `CONTRIBUTING.md` now links `docs/contributing-via-issues.md` as the start-here doc.
+
 ## [0.2.0] - 2026-04-18
 
 ### Release infrastructure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to SpecERE
 
-SpecERE is early; contributions are welcome but the design is still solidifying. Please open an issue before large changes, and read [`docs/specere_v1.md`](docs/specere_v1.md) for the phase plan before proposing anything outside Phase N.
+SpecERE is early; contributions are welcome but the design is still solidifying. **Start here for non-trivial contributions:** [`docs/contributing-via-issues.md`](docs/contributing-via-issues.md) — the bug/flaw/feature → issue → sub-issues → PR pipeline. Please open an issue before large changes, and read [`docs/specere_v1.md`](docs/specere_v1.md) for the phase plan before proposing anything outside Phase N.
 
 ## The governing rule: compose, never clone
 

--- a/crates/specere-units/src/deploy/agents/specere-reviewer.md
+++ b/crates/specere-units/src/deploy/agents/specere-reviewer.md
@@ -1,0 +1,54 @@
+---
+name: specere-reviewer
+description: Use this subagent for constitution-compliant PR / diff review. It reads `.specify/memory/constitution.md`, `docs/specere_v1.md`, and `docs/research/09_speckit_capabilities.md` §13, then evaluates the pending diff against the 10 composition rules, reversibility, per-FR test coverage, cross-platform path safety, doc-sync drift, and the narrow-parse rule. Returns a structured review.
+tools: Read, Grep, Glob, Bash
+---
+
+# specere-reviewer
+
+You are a code reviewer for the SpecERE repository. Your output is a review — not a fix, not a refactor, not a rewrite.
+
+## How to run
+
+1. **Load context** (this is cheap — the files are small):
+   - `.specify/memory/constitution.md` — the 10 composition rules + reversibility invariant + human-in-the-loop discipline + self-extension rule.
+   - `docs/specere_v1.md` — the 7-phase master plan.
+   - `docs/research/09_speckit_capabilities.md` §13 — the composition pattern.
+   - If the change references a spec: `specs/NNN-*/spec.md` + `plan.md`.
+
+2. **Identify the diff surface.** If invoked during a PR review, the prompt will tell you the base and head refs; use `git diff base..head`. If invoked on a working copy, use `git diff HEAD` or the most recent commit.
+
+3. **Evaluate** against six checks, in priority order. Block = the PR should not merge without addressing it. Nit = mention but don't block.
+
+   1. **Constitution compliance (rules 1–10).** Rules 1, 2, 4, 8, 10 are especially load-bearing — any violation is **blocking**. Example: introducing a new file format SpecERE parses without adding it to FR-P1-008's declared-format list violates rule 10.
+   2. **Reversibility (principle III).** Every new install path needs a matching `remove`. If the diff adds a `FileEntry` / `MarkerEntry` to a `Record` without corresponding strip logic, **blocking**.
+   3. **Per-FR test coverage.** A new FR named in `spec.md` without a `fr_*.rs` regression test is **blocking**. Tests need `SPECERE_TEST_SKIP_UVX=1` env when adding `speckit` (see `crates/specere/tests/common/mod.rs`).
+   4. **Cross-platform safety.** Path separators must be normalised (`deploy::rel_to_repo` replaces `\\` → `/`). Any new path construction that bypasses this is **blocking** on Windows. Also watch for `CARGO_BIN_EXE_*` usage outside the `specere` crate — tests in other crates cannot see this env var.
+   5. **Documentation drift.** `crates/**/*.rs` changes must be accompanied by `README.md` / `CHANGELOG.md` / `docs/**/*.md` / `specs/**/*.md` touches. The `docs-sync` CI job enforces this; corroborate. Nit unless the CI job is bypassed via `[skip-docs]` — then **blocking** if not justified.
+   6. **Narrow parse surface (rule 10).** New file formats must extend FR-P1-008's declared-format list. Flag with file path + reason. **Blocking**.
+
+4. **Format the review**. Output Markdown with:
+
+   ```markdown
+   ## specere-reviewer verdict
+
+   **Summary:** <one sentence — approve / approve-with-nits / request-changes>
+
+   ### Blocking
+   - [ ] <concrete finding with file:line and the rule it violates>
+
+   ### Nits
+   - <minor improvements>
+
+   ### Approved
+   - <what the diff got right — cite rule compliance explicitly>
+   ```
+
+   If there are zero blocking items, the summary is **approve** (optionally `approve-with-nits`). If there's any blocking item, the summary is **request-changes** and you list them first.
+
+## Invariants for yourself
+
+- Never auto-commit, never edit files. Read-only agent. If you find a fix, describe it; don't make it.
+- Never approve when any of the six checks surfaces a blocking item.
+- Never duplicate what the CI gates already say — corroborate, don't redo. If `rustfmt`/`clippy`/`test` are green, don't re-run them; focus on constitution-level concerns the linters can't catch.
+- Keep the review under 400 words unless the diff is > 500 lines.

--- a/crates/specere-units/src/deploy/claude_code.rs
+++ b/crates/specere-units/src/deploy/claude_code.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use specere_core::{AddUnit, Ctx, FileEntry, MarkerEntry, Owner, Plan, Record, Result};
 
-use super::{Deploy, SkillBundle};
+use super::{AgentBundle, Deploy, SkillBundle};
 
 /// The adoption skill — translates an existing repo into SpecERE's SDD stack.
 pub const SPECERE_ADOPT_SKILL: SkillBundle = SkillBundle {
@@ -39,6 +39,20 @@ const ALL_SKILLS: &[SkillBundle] = &[
     SPECERE_REVIEW_DRAIN_SKILL,
 ];
 
+/// First SpecERE-owned subagent — constitution-compliant PR / diff review.
+/// Issue #7.
+pub const SPECERE_REVIEWER_AGENT: AgentBundle = AgentBundle {
+    id: "specere-reviewer",
+    contents: include_str!("agents/specere-reviewer.md"),
+};
+
+const ALL_AGENTS: &[AgentBundle] = &[SPECERE_REVIEWER_AGENT];
+
+/// The session-durable rules text for the CLAUDE.md `rules` marker-fenced
+/// block. Issue #8. Sourced from a single file to avoid duplication with the
+/// constitution.
+const SPECERE_RULES_BODY: &str = include_str!("rules/specere-rules.md");
+
 /// Unit id used for marker-fence blocks we own.
 const UNIT_ID: &str = "claude-code-deploy";
 
@@ -67,6 +81,10 @@ impl Deploy for ClaudeCodeDeploy {
         ALL_SKILLS
     }
 
+    fn agents(&self) -> &'static [AgentBundle] {
+        ALL_AGENTS
+    }
+
     fn skill_dir(&self, ctx: &Ctx) -> PathBuf {
         ctx.repo().join(".claude").join("skills")
     }
@@ -75,6 +93,14 @@ impl Deploy for ClaudeCodeDeploy {
         PathBuf::from(".claude/skills")
             .join(skill_id)
             .join("SKILL.md")
+    }
+
+    fn agent_dir(&self, ctx: &Ctx) -> PathBuf {
+        ctx.repo().join(".claude").join("agents")
+    }
+
+    fn agent_rel_path(&self, agent_id: &str) -> PathBuf {
+        PathBuf::from(".claude/agents").join(format!("{agent_id}.md"))
     }
 }
 
@@ -170,6 +196,27 @@ impl AddUnit for ClaudeCodeDeploy {
             role: "extensions-fenced".into(),
         });
 
+        // 5. Issue #8: embed the session-durable rules block in CLAUDE.md via
+        //    a second marker-fenced section, disjoint from the existing
+        //    `harness` block the scaffold already writes there.
+        let claude_md = ctx.repo().join("CLAUDE.md");
+        let existing_cm = std::fs::read_to_string(&claude_md).unwrap_or_default();
+        let new_cm = specere_markers::upsert_block(
+            &existing_cm,
+            "rules",
+            None,
+            SPECERE_RULES_BODY.trim_end_matches('\n'),
+        )
+        .map_err(|e| specere_core::Error::Install(format!("CLAUDE.md rules fence: {e}")))?;
+        std::fs::write(&claude_md, &new_cm)
+            .map_err(|e| specere_core::Error::Install(format!("write CLAUDE.md: {e}")))?;
+        record.markers.push(MarkerEntry {
+            path: PathBuf::from("CLAUDE.md"),
+            unit_id: "rules".to_string(),
+            block_id: None,
+            sha256: specere_manifest::sha256_bytes(new_cm.as_bytes()),
+        });
+
         Ok(record)
     }
 
@@ -187,6 +234,21 @@ impl AddUnit for ClaudeCodeDeploy {
             } else {
                 std::fs::write(&gi_path, stripped)
                     .map_err(|e| specere_core::Error::Remove(format!("write .gitignore: {e}")))?;
+            }
+        }
+
+        // 2a. Strip CLAUDE.md rules fenced block (issue #8).
+        let claude_md = ctx.repo().join("CLAUDE.md");
+        if claude_md.exists() {
+            let text = std::fs::read_to_string(&claude_md)
+                .map_err(|e| specere_core::Error::Remove(format!("read CLAUDE.md: {e}")))?;
+            let stripped = specere_markers::strip_block(&text, "rules", None)
+                .map_err(|e| specere_core::Error::Remove(format!("CLAUDE.md rules strip: {e}")))?;
+            if stripped.is_empty() {
+                let _ = std::fs::remove_file(&claude_md);
+            } else {
+                std::fs::write(&claude_md, stripped)
+                    .map_err(|e| specere_core::Error::Remove(format!("write CLAUDE.md: {e}")))?;
             }
         }
 

--- a/crates/specere-units/src/deploy/mod.rs
+++ b/crates/specere-units/src/deploy/mod.rs
@@ -27,13 +27,31 @@ pub struct SkillBundle {
     pub contents: &'static str,
 }
 
+/// A subagent bundle SpecERE ships and deploys into agent harnesses.
+///
+/// Shape mirrors `SkillBundle` deliberately — same fields, same embed pattern.
+/// The difference is runtime: skills are progressive-disclosure procedures
+/// loaded on-demand; agents are isolated-context delegates the main session
+/// invokes via the `Agent` tool. See `docs/auto-review.md` and issue #6 for
+/// the rationale.
+#[derive(Debug, Clone, Copy)]
+pub struct AgentBundle {
+    pub id: &'static str,
+    pub contents: &'static str,
+}
+
 /// The harness-specific contract. Every deployer describes *where* it puts
-/// skills in the target repo; the generic install/remove logic below does the
-/// rest.
+/// skills and agents in the target repo; the generic install/remove logic
+/// below does the rest.
 pub trait Deploy {
     fn harness_id(&self) -> &'static str;
 
     fn skills(&self) -> &'static [SkillBundle];
+
+    /// Subagents the deployer ships. Default: empty (no agents). Issue #7.
+    fn agents(&self) -> &'static [AgentBundle] {
+        &[]
+    }
 
     /// Absolute directory into which a given skill's `SKILL.md` is written.
     /// Convention: `<repo>/<harness-skill-dir>/<skill.id>/SKILL.md`.
@@ -42,6 +60,22 @@ pub trait Deploy {
     /// Relative path of the skill file inside the target repo, given the
     /// skill's id. Used by manifest persistence.
     fn skill_rel_path(&self, skill_id: &str) -> PathBuf;
+
+    /// Absolute directory into which a given subagent's `<id>.md` is written.
+    /// Convention for Claude Code: `<repo>/.claude/agents/`. Default returns
+    /// the skill dir's parent + `agents/`; harness impls override for precision.
+    fn agent_dir(&self, ctx: &Ctx) -> PathBuf {
+        self.skill_dir(ctx)
+            .parent()
+            .map(|p| p.join("agents"))
+            .unwrap_or_else(|| ctx.repo().join(".claude").join("agents"))
+    }
+
+    /// Relative path of the agent file inside the target repo. Default:
+    /// `.claude/agents/<id>.md`. Harness impls override for precision.
+    fn agent_rel_path(&self, agent_id: &str) -> PathBuf {
+        PathBuf::from(".claude/agents").join(format!("{agent_id}.md"))
+    }
 }
 
 /// Generic `preflight` for any deployer.
@@ -56,6 +90,18 @@ pub fn plan<D: Deploy + ?Sized>(deployer: &D, ctx: &Ctx) -> Result<Plan> {
             path: rel,
             summary: format!("{} skill bundle", skill.id),
         });
+    }
+    if !deployer.agents().is_empty() {
+        plan.ops.push(PlanOp::CreateDir {
+            path: deployer.agent_dir(ctx),
+        });
+        for agent in deployer.agents() {
+            let rel = deployer.agent_rel_path(agent.id);
+            plan.ops.push(PlanOp::WriteFile {
+                path: rel,
+                summary: format!("{} agent bundle", agent.id),
+            });
+        }
     }
     Ok(plan)
 }
@@ -92,10 +138,36 @@ pub fn install<D: Deploy + ?Sized>(deployer: &D, ctx: &Ctx, _plan: &Plan) -> Res
         });
     }
 
+    // Agents (issue #7) — flat file layout, one file per agent id.
+    let agents = deployer.agents();
+    if !agents.is_empty() {
+        let agent_dir = deployer.agent_dir(ctx);
+        std::fs::create_dir_all(&agent_dir).map_err(|e| {
+            specere_core::Error::Install(format!("create {}: {e}", agent_dir.display()))
+        })?;
+        record.dirs.push(rel_to_repo(ctx.repo(), &agent_dir));
+
+        for agent in agents {
+            let agent_file = agent_dir.join(format!("{}.md", agent.id));
+            std::fs::write(&agent_file, agent.contents).map_err(|e| {
+                specere_core::Error::Install(format!("write {}: {e}", agent_file.display()))
+            })?;
+
+            let sha = sha256_bytes(agent.contents.as_bytes());
+            record.files.push(FileEntry {
+                path: rel_to_repo(ctx.repo(), &agent_file),
+                sha256_post: sha,
+                owner: Owner::Specere,
+                role: format!("{}-agent-{}", deployer.harness_id(), agent.id),
+            });
+        }
+    }
+
     record.notes.push(format!(
-        "{} deployer installed {} skill(s)",
+        "{} deployer installed {} skill(s) + {} agent(s)",
         deployer.harness_id(),
-        deployer.skills().len()
+        deployer.skills().len(),
+        agents.len()
     ));
     Ok(record)
 }

--- a/crates/specere-units/src/deploy/rules/specere-rules.md
+++ b/crates/specere-units/src/deploy/rules/specere-rules.md
@@ -1,0 +1,31 @@
+## SpecERE rules (session-durable)
+
+These rules govern every change agents make in this repo. They duplicate `.specify/memory/constitution.md` by design — rules loaded into every session context cannot be drowned out by a long conversation.
+
+### The 10 composition rules (NON-NEGOTIABLE)
+
+1. **Installer detects ambient git-kind.** On a git repo, never pass `--no-git`; auto-create a feature branch (`000-baseline` default). Never `--force` without a SHA-diff step.
+2. **Hook registration is the only runtime attach point.** Hooks live in `.specify/extensions.yml` only — never embed dispatch in slash-command prompts.
+3. **Template overrides go only in `.specify/templates/overrides/`.** Never edit files under `.specify/templates/` directly.
+4. **Context-file ownership uses marker-fenced blocks.** `<!-- specere:begin {unit-id} -->` … `<!-- specere:end {unit-id} -->`, one pair per unit. Content outside the fence is never touched.
+5. **`.specere/sensor-map.toml` is SpecERE-native.** Nothing else reads or writes it.
+6. **One SpecKit-registered workflow: `specere-observe`.** No parallel orchestrator.
+7. **Namespace: SpecERE slash commands are `specere-*`.** Never reuse or rename `speckit-*`.
+8. **Uninstall consults `.specere/manifest.toml`.** SHA256 match required; preserves user-edited files; delegates SpecKit core removal to `specify integration uninstall`.
+9. **Update is user-confirmed.** `specere update speckit` probes + prompts; never auto-upgrades.
+10. **Parse narrowly.** SpecERE parses YAML (`.specify/extensions.yml`), TOML (`.specere/*.toml`), JSON (`.specify/workflows/workflow-registry.json`), plain text (`.gitignore`). All other files are opaque.
+
+### NEVER list
+
+- **Never** re-implement what SpecKit or OTel GenAI semconv already does. Wrap, ignore, or extend — never clone. See `docs/research/09_speckit_capabilities.md` §13 for the 22 WRAP / 4 IGNORE / 15 EXTEND matrix.
+- **Never** edit `.specify/templates/*` directly. Overrides go in `.specify/templates/overrides/`.
+- **Never** write outside a marker-fenced block in a co-owned file (`CLAUDE.md`, `.gitignore`, `.specify/extensions.yml`, any future shared file).
+- **Never** `--force` on a re-install without first running the SHA-diff gate (FR-P1-003).
+- **Never** push to `main` directly. Every non-trivial change is a PR with `rustfmt` + `clippy` + `test × 3 OS` + `docs-sync` green.
+- **Never** tag a release without version-bump + CHANGELOG-section + `release-guards.yml` green. See `docs/release.md`.
+- **Never** block the user in the per-tool-call loop. Human-in-the-loop gates are only at `review-spec`, `review-plan`, and `divergence-adjudication` per `core_theory.md` §4.
+- **Never** silently drop a review-queue item; constitution principle V requires every `.specere/review-queue.md` entry to be drained via explicit decision (EXTEND / IGNORE / ALLOWLIST / ADJUDICATE) logged in `.specere/decisions.log`.
+
+### When in doubt
+
+Read `.specify/memory/constitution.md` — it is authoritative. This block is a session-time summary, not a replacement.

--- a/crates/specere/tests/issue_007_agent_install.rs
+++ b/crates/specere/tests/issue_007_agent_install.rs
@@ -1,0 +1,88 @@
+//! Issue #7 — claude-code-deploy installs `.claude/agents/*.md` alongside skills.
+
+mod common;
+
+use common::TempRepo;
+
+#[test]
+fn agent_file_written_on_install() {
+    let repo = TempRepo::new();
+    let out = repo
+        .run_specere(&["add", "claude-code-deploy"])
+        .output()
+        .expect("spawn");
+    assert!(
+        out.status.success(),
+        "install failed — stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let agent_file = repo.abs(".claude/agents/specere-reviewer.md");
+    assert!(
+        agent_file.exists(),
+        "expected .claude/agents/specere-reviewer.md after install"
+    );
+    let content = std::fs::read_to_string(&agent_file).unwrap();
+    assert!(
+        content.contains("name: specere-reviewer"),
+        "agent file missing frontmatter name:\n{content}"
+    );
+    assert!(
+        content.contains("constitution"),
+        "agent prompt missing constitution mention"
+    );
+}
+
+#[test]
+fn remove_strips_agent_file() {
+    let repo = TempRepo::new();
+    assert!(repo
+        .run_specere(&["add", "claude-code-deploy"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+    assert!(repo.abs(".claude/agents/specere-reviewer.md").exists());
+
+    assert!(repo
+        .run_specere(&["remove", "claude-code-deploy"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+    assert!(
+        !repo.abs(".claude/agents/specere-reviewer.md").exists(),
+        "agent file should be stripped on remove"
+    );
+}
+
+#[test]
+fn manifest_records_agent_role() {
+    let repo = TempRepo::new();
+    assert!(repo
+        .run_specere(&["add", "claude-code-deploy"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    let m: toml::Value =
+        toml::from_str(&std::fs::read_to_string(repo.abs(".specere/manifest.toml")).unwrap())
+            .unwrap();
+    let deploy = m["units"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t["id"].as_str() == Some("claude-code-deploy"))
+        .unwrap();
+    let files = deploy["files"].as_array().unwrap();
+    let agent_entry = files
+        .iter()
+        .find(|f| f["path"].as_str() == Some(".claude/agents/specere-reviewer.md"))
+        .expect("agent in manifest");
+    assert_eq!(
+        agent_entry["role"].as_str(),
+        Some("claude-code-agent-specere-reviewer"),
+        "agent role string mismatch"
+    );
+}

--- a/crates/specere/tests/issue_008_rules_block.rs
+++ b/crates/specere/tests/issue_008_rules_block.rs
@@ -1,0 +1,99 @@
+//! Issue #8 — claude-code-deploy writes a `rules` marker-fenced block in
+//! CLAUDE.md, disjoint from the existing `harness` block.
+
+mod common;
+
+use common::TempRepo;
+
+#[test]
+fn rules_block_written_on_install_when_claude_md_absent() {
+    let repo = TempRepo::new();
+    assert!(!repo.abs("CLAUDE.md").exists());
+
+    assert!(repo
+        .run_specere(&["add", "claude-code-deploy"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    let cm = std::fs::read_to_string(repo.abs("CLAUDE.md")).unwrap();
+    assert!(cm.contains("<!-- specere:begin rules -->"));
+    assert!(cm.contains("<!-- specere:end rules -->"));
+    assert!(
+        cm.contains("The 10 composition rules"),
+        "rules body missing:\n{cm}"
+    );
+}
+
+#[test]
+fn rules_block_coexists_with_user_claude_md() {
+    let repo = TempRepo::new();
+    let user_content = "# My project\n\nSome user notes.\n";
+    repo.write("CLAUDE.md", user_content);
+
+    assert!(repo
+        .run_specere(&["add", "claude-code-deploy"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    let cm = std::fs::read_to_string(repo.abs("CLAUDE.md")).unwrap();
+    assert!(
+        cm.starts_with("# My project"),
+        "user content clobbered:\n{cm}"
+    );
+    assert!(cm.contains("<!-- specere:begin rules -->"));
+}
+
+#[test]
+fn round_trip_leaves_claude_md_byte_identical() {
+    let repo = TempRepo::new();
+    let original = "# Project\n\n<!-- SPECKIT START -->\npointer to plan\n<!-- SPECKIT END -->\n";
+    repo.write("CLAUDE.md", original);
+
+    assert!(repo
+        .run_specere(&["add", "claude-code-deploy"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+    assert!(repo
+        .run_specere(&["remove", "claude-code-deploy"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    let after = std::fs::read_to_string(repo.abs("CLAUDE.md")).unwrap();
+    assert_eq!(
+        original, after,
+        "CLAUDE.md not byte-identical after round-trip"
+    );
+}
+
+#[test]
+fn rules_block_stripped_on_remove() {
+    let repo = TempRepo::new();
+    assert!(repo
+        .run_specere(&["add", "claude-code-deploy"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+    assert!(repo
+        .run_specere(&["remove", "claude-code-deploy"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    if repo.abs("CLAUDE.md").exists() {
+        let cm = std::fs::read_to_string(repo.abs("CLAUDE.md")).unwrap();
+        assert!(!cm.contains("specere:begin rules"));
+        assert!(!cm.contains("10 composition rules"));
+    }
+    // If CLAUDE.md was removed entirely because it became empty, that also
+    // satisfies "rules block stripped".
+}

--- a/docs/contributing-via-issues.md
+++ b/docs/contributing-via-issues.md
@@ -1,0 +1,80 @@
+# Contributing via issues
+
+The canonical pipeline for non-trivial SpecERE work: **bug / flaw / feature** → **parent issue** → *(optional)* **sub-issues** → **branch(es)** → **PR(s)** → **CI green** → **merge**. This is how the harness itself got built — PRs #2 through #6 followed exactly this shape.
+
+Read this before opening an issue or a PR larger than a typo fix.
+
+## The 10 steps
+
+1. **Spot.** You notice a bug, a design flaw, or a missing capability. First check `docs/upcoming.md` — if it's already queued, either pick it up or wait. If not, proceed.
+2. **Open a parent issue.** Use https://github.com/laiadlotape/specere/issues/new. Body template:
+   ```markdown
+   ## Problem
+   <one paragraph, concrete, links where the gap is visible>
+
+   ## Why it matters
+   <impact, who is blocked, what breaks>
+
+   ## Proposed fix (shape)
+   <bullets; scope-bounded; cite the constitution rule or phase if applicable>
+
+   ## Non-goals
+   <explicit out-of-scope bullets so scope creep has a place to land>
+
+   ## Acceptance
+   <bullets naming files, commands, tests, or SCs that should pass>
+   ```
+   Issue #6 (this feature's own parent) follows that template — re-read it as a reference.
+3. **Decide scope.** Heuristic: if the fix is ≤ 200 LoC across ≤ 5 files with one cohesive concern, **skip sub-issues** — one PR is enough. Otherwise open a sub-issue per independently-deliverable piece. Each sub-issue's body starts with `Parent: #<N>` and uses the same template.
+4. **Link sub-issues.** GitHub's native sub-issue feature GA'd in 2025; after creating each sub-issue, link it:
+   ```sh
+   SUB_ID=$(gh api repos/laiadlotape/specere/issues/<sub-number> --jq .id)
+   gh api "repos/laiadlotape/specere/issues/<parent-number>/sub_issues" -X POST -F "sub_issue_id=$SUB_ID"
+   ```
+   The parent's issue page then renders the child list with a progress bar.
+5. **Branch naming.** `NNN-short-slug` — `NNN` is the next free 3-digit counter matching `specs/` (e.g. the last was `005-release-infra`, so next is `006-…`). The slug is 2-5 words of the parent issue's topic.
+6. **Optionally run `/speckit-specify`.** FR-bearing work (anything adding a constitution rule, a test-able FR, or a user-facing CLI surface) runs the full `/speckit-observe` workflow — `/speckit-specify → /speckit-clarify → /speckit-plan → /speckit-tasks → /speckit-implement` — scaffolding `specs/NNN-.../`. Pure-docs / pure-infra issues can skip and go straight to a PR.
+7. **PR per sub-issue** by default. Open the PR as soon as the branch has a coherent first commit. The body template:
+   ```markdown
+   ## Summary
+   <one paragraph + bullet list>
+
+   Fixes #<parent>
+   Closes #<sub1>, #<sub2>, #<sub3>   <!-- if single PR closes multiple sub-issues -->
+
+   ## Test plan
+   - [ ] <per-check boxes>
+
+   ## Post-merge
+   <housekeeping; upcoming.md updates; follow-up issues>
+   ```
+   The `Fixes` + `Closes` lines auto-close the referenced issues on merge.
+8. **CI gates (authoritative).** `rustfmt`, `clippy`, `test (ubuntu-latest)`, `test (macos-latest)`, `test (windows-latest)`, `docs-sync`. Plus the advisory `review` job (Claude auto-review — see [`auto-review.md`](auto-review.md)). Fix red X's before asking for review; the review is not a substitute for the required checks.
+9. **Merge via merge-commit.** `gh pr merge <n> --merge --delete-branch`. Keep the PR's commit history — `/speckit-*` workflow trails are themselves documentation. Do **not** squash unless the history is genuinely noisy (rebase-and-dance, many fixup commits).
+10. **Post-merge cleanup.**
+    - Strike the parent issue off the priority queue in [`docs/upcoming.md`](upcoming.md); add a one-line entry under `## Recently closed`.
+    - If the merge cut a release tag, update the `## Status` table in [`README.md`](../README.md) — the `docs-sync` CI enforces this, but the update is your responsibility.
+    - If the work surfaced any follow-ups you deferred, open them as fresh issues immediately — don't let them live in your head.
+
+## Examples (from the git log)
+
+| PR | Parent issue | Sub-issues | Notes |
+|---|---|---|---|
+| #2 | n/a (scaffold phase) | — | Phase 1 bugfix release, 9 FRs, 37 tests. Full `/speckit-observe` workflow. |
+| #3 | n/a (drift fix) | — | README sync + `docs-sync` CI gate added. Self-validating. |
+| #4 | n/a (follow-up) | — | Auto-review CI job + subsumes Dependabot #1. |
+| #5 | n/a (follow-up) | — | Release infra — closed `docs/upcoming.md` priority 1. |
+| #6 | #6 (meta) | #7, #8, #9 | Harness-gap for subagents + rules + this doc. |
+
+## Anti-patterns
+
+- **Single PR bundling three unrelated issues.** Breaks merge-commit story-telling; makes bisect useless. Open three PRs instead.
+- **Feature branch off `main` without an issue.** Fine for a typo fix; not fine for anything that could generate follow-up discussion. If reviewers will want to discuss *why*, the discussion belongs on an issue, not scattered across PR comments.
+- **Skipping `docs-sync`** via `[skip-docs]` without justification. The escape hatch is for pure refactors / renames / CI-only changes, not for "I'll update docs in a follow-up PR" — which never happens.
+- **Merging your own PR with a red `review` check** you didn't read. The job is advisory but the Claude review output is often a free round of critique; skim it before merge.
+
+## When *not* to use this flow
+
+- Typo fix in a comment or doc — just PR it. No issue needed.
+- Obvious one-line bug fix with a regression test — PR it; issue only if there's user discussion to capture.
+- Dependabot / Renovate automated bumps — they open their own PRs; review + merge directly.


### PR DESCRIPTION
## Summary

Closes #7, #8, #9. Fixes #6.

Addresses the harness gap the user surfaced: `claude-code-deploy` shipped **skills only** — no subagents, no session-durable rules. Per [Claude Code's 2026 harness-engineering guidance](https://www.humanlayer.dev/blog/skill-issue-harness-engineering-for-coding-agents), a complete harness composes **three** surfaces:

| Surface | Purpose | Status before | Status now |
|---|---|---|---|
| `.claude/skills/*/SKILL.md` | procedures, progressive disclosure | ✅ shipped | ✅ unchanged |
| `.claude/agents/*.md` | isolated-context subagents | ❌ absent | ✅ `specere-reviewer` shipped |
| `CLAUDE.md` rules block | session-durable policy | ❌ absent | ✅ `<!-- specere:begin rules -->` block |

Plus: **`docs/contributing-via-issues.md`** — the 10-step bug/flaw/feat → parent issue → sub-issues → PR pipeline. This PR is itself the first worked example (parent #6 → sub #7, #8, #9 → this single PR).

## Changes

### `AgentBundle` + Deploy trait extension (#7)
- New `AgentBundle` mirroring `SkillBundle` in `crates/specere-units/src/deploy/mod.rs`.
- `Deploy` trait: `agents()`, `agent_dir()`, `agent_rel_path()` with sensible defaults (empty slice, `.claude/agents/`).
- Generic `plan` / `install` write `<agent_dir>/<id>.md` and record role `<harness>-agent-<id>`.
- `ClaudeCodeDeploy` registers one agent: `specere-reviewer`.

### CLAUDE.md rules block (#8)
- Second marker-fenced block beside the existing `harness` block.
- Body = 10 composition rules + NEVER list, sourced from single `include_str!` file (`deploy/rules/specere-rules.md`) so rule text doesn't drift from constitution.
- Remove strips cleanly — byte-identical round-trip per FR-P1-006.

### Contributing doc (#9)
- 10-step pipeline with issue body template, sub-issue linking command (`gh api … sub_issues`), branch-naming convention, merge-commit rationale, anti-patterns.
- Links from `CONTRIBUTING.md` as start-here doc.

## Test plan

- [x] `cargo test --workspace --all-targets`: **44 passed**, 0 failed (up from 37 — +7 from new issue-linked tests).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- [x] `cargo fmt --all -- --check`: clean.
- [ ] CI gates (`rustfmt`, `clippy`, `test × 3 OS`, `docs-sync`, `review`).

## Regression coverage

- `crates/specere/tests/issue_007_agent_install.rs` (3 scenarios): agent file written, stripped on remove, manifest records correct role.
- `crates/specere/tests/issue_008_rules_block.rs` (4 scenarios): rules block written on fresh CLAUDE.md, coexists with user content, round-trip byte-identical with SpecKit block, stripped on remove.

## Post-merge

- Strike #6, #7, #8, #9 (auto-closed by merge).
- Next queue head (from `docs/upcoming.md`): `phase-2-native-units` — now unblocked by the expanded harness surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)