### PR TITLE
feat(filter-state): promote stub to real AddUnit + gitignore allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to SpecERE will be documented here. The format follows [Keep
 
 ## [Unreleased]
 
+### Added (Phase 2)
+- **`filter-state` unit** promoted from `stub::StubUnit` to real `AddUnit` at `crates/specere-units/src/filter_state.rs`. FR-P2-001 / issue #12. Install creates `.specere/{events.sqlite, posterior.toml, sensor-map.toml}` skeleton and writes a marker-fenced `.gitignore` block with `.specere/*` + allowlist (`!manifest.toml`, `!sensor-map.toml`, `!review-queue.md`, `!decisions.log`, `!posterior.toml`). Remove is byte-identical round-trip. Idempotent via the existing FR-P1-003 SHA-diff gate. 6 regression scenarios in `crates/specere/tests/fr_p2_001_filter_state.rs`.
+
 ### Added
 - `AgentBundle` in `crates/specere-units/src/deploy/mod.rs` alongside the existing `SkillBundle`. `Deploy` trait gains `agents()` + `agent_dir()` + `agent_rel_path()` with sensible defaults. Issue #7.
 - First SpecERE subagent shipped via `claude-code-deploy`: `specere-reviewer` at `.claude/agents/specere-reviewer.md`, a constitution-compliant PR/diff reviewer. Matches the CI `review` job's prompt but usable interactively via the `Agent` tool. Issue #7.

--- a/crates/specere-units/src/filter_state.rs
+++ b/crates/specere-units/src/filter_state.rs
@@ -1,0 +1,204 @@
+//! `specere add filter-state` — native unit that lays down the
+//! `.specere/` skeleton and the `.gitignore` allowlist that lets the filter
+//! engine (Phase 4) and observe pipeline (Phase 3) write runtime state
+//! without leaking it into git.
+//!
+//! Issue #12 / FR-P2-001.
+
+use std::path::PathBuf;
+
+use specere_core::{AddUnit, Ctx, FileEntry, MarkerEntry, Owner, Plan, PlanOp, Record, Result};
+
+const UNIT_ID: &str = "filter-state";
+
+const EVENTS_SQLITE_CONTENT: &[u8] = b"";
+
+const POSTERIOR_TOML_CONTENT: &str = concat!(
+    "# SpecERE filter posterior. Phase 4 populates per-spec entries below.\n",
+    "schema_version = 1\n",
+);
+
+const SENSOR_MAP_TOML_CONTENT: &str = concat!(
+    "# SpecERE sensor map — Repo-SLAM sensor channel registry.\n",
+    "#\n",
+    "# SpecERE-native (10-rule #5). Populated by `specere-adopt` or by hand.\n",
+    "#\n",
+    "# Channels (see docs/analysis/core_theory.md §3 in ReSearch):\n",
+    "#   A = test / contract measurements\n",
+    "#   B = read-tool observations\n",
+    "#   C = harness-intrinsic signals\n",
+    "#   D = invariants / PBT / mutation\n",
+    "\n",
+    "schema_version = 1\n",
+    "\n",
+    "[channels]\n",
+    "# (empty — populated per-spec as the sensor array grows)\n",
+);
+
+const GITIGNORE_BODY_LINES: &[&str] = &[
+    ".specere/*",
+    "!.specere/manifest.toml",
+    "!.specere/sensor-map.toml",
+    "!.specere/review-queue.md",
+    "!.specere/decisions.log",
+    "!.specere/posterior.toml",
+];
+
+pub struct FilterState;
+
+impl AddUnit for FilterState {
+    fn id(&self) -> &'static str {
+        UNIT_ID
+    }
+
+    fn pinned_version(&self) -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn preflight(&self, _ctx: &Ctx) -> Result<Plan> {
+        let mut plan = Plan::default();
+        plan.ops.push(PlanOp::CreateDir {
+            path: PathBuf::from(".specere"),
+        });
+        for (name, _) in skeleton_files() {
+            plan.ops.push(PlanOp::WriteFile {
+                path: PathBuf::from(".specere").join(name),
+                summary: format!("filter-state skeleton: {name}"),
+            });
+        }
+        plan.ops.push(PlanOp::UpsertMarker {
+            path: PathBuf::from(".gitignore"),
+            block_id: UNIT_ID.to_string(),
+        });
+        Ok(plan)
+    }
+
+    fn install(&self, ctx: &Ctx, _plan: &Plan) -> Result<Record> {
+        let specere_dir = ctx.repo().join(".specere");
+        std::fs::create_dir_all(&specere_dir).map_err(|e| {
+            specere_core::Error::Install(format!("create {}: {e}", specere_dir.display()))
+        })?;
+
+        let mut record = Record::default();
+        record.dirs.push(PathBuf::from(".specere"));
+
+        for (name, content) in skeleton_files() {
+            let abs = specere_dir.join(name);
+            // Only write if absent. If the target already has this file (e.g.
+            // from the session harness on specere's own repo), adopt the
+            // existing content and record its SHA.
+            let wrote = if !abs.exists() {
+                std::fs::write(&abs, content).map_err(|e| {
+                    specere_core::Error::Install(format!("write {}: {e}", abs.display()))
+                })?;
+                true
+            } else {
+                false
+            };
+            let on_disk = std::fs::read(&abs).map_err(|e| {
+                specere_core::Error::Install(format!("re-read {}: {e}", abs.display()))
+            })?;
+            let sha = specere_manifest::sha256_bytes(&on_disk);
+            record.files.push(FileEntry {
+                path: PathBuf::from(".specere").join(name),
+                sha256_post: sha,
+                owner: if wrote {
+                    Owner::Specere
+                } else {
+                    Owner::UserEditedAfterInstall
+                },
+                role: format!(
+                    "filter-state-{}",
+                    name.trim_end_matches(".toml").trim_end_matches(".sqlite")
+                ),
+            });
+        }
+
+        // .gitignore marker block.
+        let gi_path = ctx.repo().join(".gitignore");
+        let existing = std::fs::read_to_string(&gi_path).unwrap_or_default();
+        let new_ign =
+            specere_markers::text_block_fence::add(&existing, UNIT_ID, GITIGNORE_BODY_LINES)
+                .map_err(|e| specere_core::Error::Install(format!("gitignore fence: {e}")))?;
+        std::fs::write(&gi_path, &new_ign)
+            .map_err(|e| specere_core::Error::Install(format!("write .gitignore: {e}")))?;
+        record.files.push(FileEntry {
+            path: PathBuf::from(".gitignore"),
+            sha256_post: specere_manifest::sha256_bytes(new_ign.as_bytes()),
+            owner: Owner::Specere,
+            role: "filter-state-gitignore".into(),
+        });
+        record.markers.push(MarkerEntry {
+            path: PathBuf::from(".gitignore"),
+            unit_id: UNIT_ID.to_string(),
+            block_id: None,
+            sha256: specere_manifest::sha256_bytes(new_ign.as_bytes()),
+        });
+
+        record.notes.push(format!(
+            "filter-state installed skeleton ({} file(s))",
+            skeleton_files().len()
+        ));
+        Ok(record)
+    }
+
+    fn remove(&self, ctx: &Ctx, record: &Record) -> Result<()> {
+        // 1) Strip the .gitignore fenced block; if the file becomes empty,
+        //    delete it (matches pre-install state on a fresh fixture).
+        let gi_path = ctx.repo().join(".gitignore");
+        if gi_path.exists() {
+            let text = std::fs::read_to_string(&gi_path)
+                .map_err(|e| specere_core::Error::Remove(format!("read .gitignore: {e}")))?;
+            let stripped = specere_markers::text_block_fence::remove(&text, UNIT_ID)
+                .map_err(|e| specere_core::Error::Remove(format!("gitignore strip: {e}")))?;
+            if stripped.is_empty() {
+                let _ = std::fs::remove_file(&gi_path);
+            } else {
+                std::fs::write(&gi_path, stripped)
+                    .map_err(|e| specere_core::Error::Remove(format!("write .gitignore: {e}")))?;
+            }
+        }
+
+        // 2) Delete skeleton files whose on-disk SHA still matches what the
+        //    manifest recorded. User-edited files are preserved with a warning.
+        for f in &record.files {
+            if f.path.as_os_str() == std::ffi::OsStr::new(".gitignore") {
+                continue;
+            }
+            let abs = ctx.repo().join(&f.path);
+            if !abs.exists() {
+                continue;
+            }
+            if f.owner == Owner::UserEditedAfterInstall {
+                tracing::warn!(
+                    "filter-state: `{}` marked user-edited at install; preserving on remove",
+                    f.path.display()
+                );
+                continue;
+            }
+            let actual = specere_manifest::sha256_file(&abs).map_err(|e| {
+                specere_core::Error::Remove(format!("sha256 {}: {e}", abs.display()))
+            })?;
+            if actual != f.sha256_post {
+                tracing::warn!(
+                    "filter-state: `{}` edited after install; preserving",
+                    f.path.display()
+                );
+                continue;
+            }
+            std::fs::remove_file(&abs).map_err(|e| {
+                specere_core::Error::Remove(format!("remove {}: {e}", abs.display()))
+            })?;
+        }
+
+        Ok(())
+    }
+}
+
+fn skeleton_files() -> [(&'static str, &'static [u8]); 3] {
+    [
+        ("events.sqlite", EVENTS_SQLITE_CONTENT),
+        ("posterior.toml", POSTERIOR_TOML_CONTENT.as_bytes()),
+        ("sensor-map.toml", SENSOR_MAP_TOML_CONTENT.as_bytes()),
+    ]
+}

--- a/crates/specere-units/src/lib.rs
+++ b/crates/specere-units/src/lib.rs
@@ -6,6 +6,7 @@ use specere_core::{AddUnit, Ctx, Owner};
 use specere_manifest::{record_to_unit_entry, sha256_file, Manifest};
 
 pub mod deploy;
+pub mod filter_state;
 pub mod speckit;
 
 pub const SPECERE_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -28,10 +29,7 @@ pub fn lookup(id: &str, flags: &AddFlags) -> Option<Box<dyn AddUnit>> {
             },
         ))),
         "claude-code-deploy" => Some(Box::new(deploy::claude_code::ClaudeCodeDeploy)),
-        "filter-state" => Some(Box::new(stub::StubUnit {
-            id: "filter-state",
-            reason: "planned in 0.1.0 MVP; not yet implemented",
-        })),
+        "filter-state" => Some(Box::new(filter_state::FilterState)),
         "otel-collector" => Some(Box::new(stub::StubUnit {
             id: "otel-collector",
             reason: "planned in 0.1.0 MVP; not yet implemented",

--- a/crates/specere/tests/fr_p2_001_filter_state.rs
+++ b/crates/specere/tests/fr_p2_001_filter_state.rs
@@ -1,0 +1,167 @@
+//! FR-P2-001. `filter-state` unit creates `.specere/` skeleton + gitignore
+//! allowlist, is idempotent, and round-trips cleanly.
+//!
+//! Issue #12 acceptance criteria:
+//! - Install writes .specere/{events.sqlite, posterior.toml, sensor-map.toml}
+//! - .gitignore has `.specere/*` + allowlist block (marker-fenced)
+//! - Idempotent re-install is a no-op
+//! - Remove inverts cleanly (byte-identical round-trip)
+//! - Manifest records every file with role `filter-state-*`
+
+mod common;
+
+use common::TempRepo;
+
+fn install(repo: &TempRepo) {
+    let out = repo
+        .run_specere(&["add", "filter-state"])
+        .output()
+        .expect("spawn");
+    assert!(
+        out.status.success(),
+        "install failed — exit {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn fresh_install_creates_skeleton() {
+    let repo = TempRepo::new();
+    install(&repo);
+
+    assert!(repo.abs(".specere").is_dir(), ".specere/ dir not created");
+    assert!(repo.abs(".specere/events.sqlite").exists());
+    assert!(repo.abs(".specere/posterior.toml").exists());
+    assert!(repo.abs(".specere/sensor-map.toml").exists());
+
+    // posterior.toml must carry a schema_version stamp (Phase 3+ filter engine
+    // reads this).
+    let p = std::fs::read_to_string(repo.abs(".specere/posterior.toml")).unwrap();
+    assert!(
+        p.contains("schema_version"),
+        "posterior.toml missing schema_version:\n{p}"
+    );
+}
+
+#[test]
+fn install_writes_gitignore_marker_block_with_allowlist() {
+    let repo = TempRepo::new();
+    install(&repo);
+
+    let ign = std::fs::read_to_string(repo.abs(".gitignore")).unwrap();
+    assert!(
+        ign.contains("specere:begin filter-state"),
+        ".gitignore missing filter-state marker block:\n{ign}"
+    );
+    assert!(
+        ign.contains(".specere/*"),
+        ".gitignore missing .specere/* glob"
+    );
+    // Allowlist: at least these four must survive a `git clean -fX`.
+    for keep in [
+        "!.specere/manifest.toml",
+        "!.specere/sensor-map.toml",
+        "!.specere/review-queue.md",
+        "!.specere/decisions.log",
+    ] {
+        assert!(
+            ign.contains(keep),
+            ".gitignore missing allowlist entry `{keep}`:\n{ign}"
+        );
+    }
+}
+
+#[test]
+fn gitignore_preserves_user_lines() {
+    let repo = TempRepo::new();
+    repo.write(".gitignore", "/target\n*.log\n");
+    install(&repo);
+
+    let ign = std::fs::read_to_string(repo.abs(".gitignore")).unwrap();
+    assert!(
+        ign.starts_with("/target\n*.log"),
+        "pre-existing .gitignore content altered:\n{ign}"
+    );
+    assert!(ign.contains("specere:begin filter-state"));
+}
+
+#[test]
+fn reinstall_is_idempotent() {
+    let repo = TempRepo::new();
+    install(&repo);
+    let sha_before = sha_of(&repo.abs(".gitignore"));
+    let out = repo
+        .run_specere(&["add", "filter-state"])
+        .output()
+        .expect("spawn");
+    assert!(
+        out.status.success(),
+        "re-install should be a no-op; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let sha_after = sha_of(&repo.abs(".gitignore"));
+    assert_eq!(
+        sha_before, sha_after,
+        "re-install mutated .gitignore — not idempotent"
+    );
+}
+
+#[test]
+fn remove_round_trip_is_byte_identical() {
+    let repo = TempRepo::new();
+    let original = "/target\n*.log\n";
+    repo.write(".gitignore", original);
+    let pre = std::fs::read_to_string(repo.abs(".gitignore")).unwrap();
+
+    install(&repo);
+    let out = repo
+        .run_specere(&["remove", "filter-state"])
+        .output()
+        .expect("spawn");
+    assert!(
+        out.status.success(),
+        "remove failed — stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let post = std::fs::read_to_string(repo.abs(".gitignore")).unwrap();
+    assert_eq!(pre, post, ".gitignore not byte-identical after round-trip");
+    assert!(!repo.abs(".specere").exists(), ".specere/ not removed");
+}
+
+#[test]
+fn manifest_records_files_with_filter_state_role() {
+    let repo = TempRepo::new();
+    install(&repo);
+
+    let m: toml::Value =
+        toml::from_str(&std::fs::read_to_string(repo.abs(".specere/manifest.toml")).unwrap())
+            .unwrap();
+    let fs_unit = m["units"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t["id"].as_str() == Some("filter-state"))
+        .expect("filter-state in manifest");
+    let files = fs_unit["files"].as_array().unwrap();
+    let roles: Vec<&str> = files
+        .iter()
+        .map(|f| f["role"].as_str().unwrap_or(""))
+        .collect();
+    // Every recorded file's role starts with filter-state- (skeleton entries).
+    for role in &roles {
+        assert!(
+            role.starts_with("filter-state-"),
+            "role `{role}` doesn't match `filter-state-*`"
+        );
+    }
+}
+
+fn sha_of(path: &std::path::Path) -> String {
+    use sha2::{Digest, Sha256};
+    let bytes = std::fs::read(path).unwrap_or_default();
+    let mut h = Sha256::new();
+    h.update(&bytes);
+    hex::encode(h.finalize())
+}


### PR DESCRIPTION
## Summary

Fixes #12. First sub-issue of Phase 2 (parent #11) per [\`docs/phase2-execution-plan.md\`](../blob/main/docs/phase2-execution-plan.md) recipe.

- **\`filter-state\` unit** promoted from stub to real at \`crates/specere-units/src/filter_state.rs\`.
- Install creates \`.specere/{events.sqlite, posterior.toml, sensor-map.toml}\` skeleton + marker-fenced \`.gitignore\` block with \`.specere/*\` + allowlist.
- Remove: byte-identical round-trip — strips gitignore block, SHA-checks + deletes skeleton files, preserves user-edited ones with a warning.
- Co-exists with pre-existing state: on a repo that already has a \`.specere/\` skeleton (e.g. specere's own harness branch), files are adopted with \`owner=UserEditedAfterInstall\`.

## Test plan

- [x] \`cargo test --workspace --all-targets\`: **50/50** (was 44).
- [x] \`cargo clippy -- -D warnings\`: clean.
- [x] \`cargo fmt --check\`: clean.
- [ ] CI gates (\`rustfmt\` · \`clippy\` · \`test × 3 OS\` · \`docs-sync\` · \`review\`).

## Regression scenarios

\`crates/specere/tests/fr_p2_001_filter_state.rs\` (6 tests):

1. Fresh install creates the three skeleton files + \`.specere/\` dir.
2. Install writes gitignore marker block with all allowlist entries.
3. Pre-existing gitignore user lines preserved.
4. Idempotent re-install (dispatcher's SHA-diff gate covers).
5. Byte-identical round-trip after install + remove.
6. Manifest records all files with \`filter-state-*\` role prefix.

## Plan re-check (§5 of the execution plan)

- Test-count deviation: **0** — estimate was 5, delivered 6 (within ±20%).
- Scope: ~190 LoC impl, 170 LoC tests — well under the 500 LoC threshold.
- Contract changes: none — used existing \`AddUnit\` / \`specere-markers::text_block_fence\` APIs.
- Novel review-queue items: none observed.

**No re-plan triggers fired. Proceeding to #16 after merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)