### PR TITLE
feat(orphan): speckit preflight + doctor --clean-orphans (issue #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to SpecERE will be documented here. The format follows [Keep
 ## [Unreleased]
 
 ### Added (Phase 2)
+- **`speckit::preflight` orphan-state detector** (issue #16, carry-over from 2026-04-18 `.specere/decisions.log` EXTEND). Detects orphan `.specify/feature.json` + `specs/NNN-*/spec.md` (template-only) left by aborted `specify workflow run` subprocesses; raises `Error::OrphanFeatureDir` with exit code 8 + actionable help pointing at `specere doctor --clean-orphans`. New subcommand flag sweeps filesystem artifacts (spec dir + feature.json + orphan workflow-run dirs). Does not touch git branches. 4 regression scenarios in `crates/specere/tests/fr_p2_orphan_detector.rs`. New module: `crates/specere-units/src/orphan.rs`.
 - **`filter-state` unit** promoted from `stub::StubUnit` to real `AddUnit` at `crates/specere-units/src/filter_state.rs`. FR-P2-001 / issue #12. Install creates `.specere/{events.sqlite, posterior.toml, sensor-map.toml}` skeleton and writes a marker-fenced `.gitignore` block with `.specere/*` + allowlist (`!manifest.toml`, `!sensor-map.toml`, `!review-queue.md`, `!decisions.log`, `!posterior.toml`). Remove is byte-identical round-trip. Idempotent via the existing FR-P1-003 SHA-diff gate. 6 regression scenarios in `crates/specere/tests/fr_p2_001_filter_state.rs`.
 
 ### Added

--- a/crates/specere-core/src/lib.rs
+++ b/crates/specere-core/src/lib.rs
@@ -55,6 +55,11 @@ pub enum Error {
     /// branch was not SpecERE-created.
     #[error("refusing to delete branch `{branch}`: not created by SpecERE (branch_was_created_by_specere=false)")]
     BranchNotOurs { branch: String },
+    /// Issue #16. Raised by `speckit::preflight` when an aborted
+    /// `specify workflow run` has left a ghost `.specify/feature.json`
+    /// + `specs/NNN-*/spec.md` (template-only) on disk.
+    #[error("orphan .specify state detected at `{feature_dir}` (feature.json points here, but spec.md is still the unfilled template). Run `specere doctor --clean-orphans` to sweep.", feature_dir = feature_dir.display())]
+    OrphanFeatureDir { feature_dir: std::path::PathBuf },
     #[error("other: {0}")]
     Other(#[from] anyhow::Error),
 }
@@ -68,6 +73,7 @@ impl Error {
             Self::DeletedOwnedFile { .. } => 4,
             Self::BranchDirty { .. } => 6,
             Self::BranchNotOurs { .. } => 7,
+            Self::OrphanFeatureDir { .. } => 8,
             _ => 1,
         }
     }

--- a/crates/specere-units/src/lib.rs
+++ b/crates/specere-units/src/lib.rs
@@ -7,6 +7,7 @@ use specere_manifest::{record_to_unit_entry, sha256_file, Manifest};
 
 pub mod deploy;
 pub mod filter_state;
+pub mod orphan;
 pub mod speckit;
 
 pub const SPECERE_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -293,6 +294,24 @@ pub fn verify(ctx: &Ctx) -> anyhow::Result<()> {
         println!("{drift} drift entries.");
     }
     Ok(())
+}
+
+/// Sweep orphan `.specify/` state (issue #16). Non-destructive if no orphan
+/// is detected. Returns the number of orphan artifact groups cleaned.
+pub fn clean_orphans(ctx: &Ctx) -> anyhow::Result<usize> {
+    match orphan::detect(ctx.repo()) {
+        Some(state) => {
+            let n = 1 + state.orphan_runs.len();
+            orphan::clean(ctx.repo(), &state)?;
+            tracing::info!(
+                "cleaned orphan feature dir at `{}` + {} workflow-run artifact(s)",
+                state.feature_dir.display(),
+                state.orphan_runs.len()
+            );
+            Ok(n)
+        }
+        None => Ok(0),
+    }
 }
 
 pub fn doctor(ctx: &Ctx) -> anyhow::Result<()> {

--- a/crates/specere-units/src/orphan.rs
+++ b/crates/specere-units/src/orphan.rs
@@ -1,0 +1,112 @@
+//! Orphan-state detection for SpecKit artifacts left behind by aborted
+//! `specify workflow run` invocations (issue #16, carry-over from
+//! `.specere/decisions.log` 2026-04-18 EXTEND).
+//!
+//! Heuristic: `.specify/feature.json` references a `specs/NNN-*/` dir whose
+//! `spec.md` is still the unfilled template — identified by the presence of
+//! the verbatim `[FEATURE NAME]` placeholder in the first 20 lines.
+
+use std::path::{Path, PathBuf};
+
+/// Describes an orphan state on disk, if one is detected.
+#[derive(Debug, Clone)]
+pub struct OrphanState {
+    /// Absolute path to the feature directory referenced by `.specify/feature.json`.
+    pub feature_dir: PathBuf,
+    /// Orphan workflow-run dirs under `.specify/workflows/runs/` (if any).
+    pub orphan_runs: Vec<PathBuf>,
+}
+
+/// Inspect `repo` for orphan SpecKit state. Returns `Some(OrphanState)` iff
+/// the heuristic in this module's doc comment matches.
+pub fn detect(repo: &Path) -> Option<OrphanState> {
+    let feature_json = repo.join(".specify").join("feature.json");
+    if !feature_json.is_file() {
+        return None;
+    }
+    let raw = std::fs::read_to_string(&feature_json).ok()?;
+    let dir_rel = parse_feature_directory(&raw)?;
+    let feature_dir = repo.join(&dir_rel);
+    if !feature_dir.is_dir() {
+        return None;
+    }
+    let spec_md = feature_dir.join("spec.md");
+    if !spec_md.is_file() {
+        return None;
+    }
+    if !spec_md_is_template(&spec_md) {
+        return None;
+    }
+
+    // Optional: include orphan workflow-runs dirs in the state for sweeping.
+    let runs_root = repo.join(".specify").join("workflows").join("runs");
+    let orphan_runs = if runs_root.is_dir() {
+        std::fs::read_dir(&runs_root)
+            .ok()
+            .into_iter()
+            .flatten()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.is_dir())
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    Some(OrphanState {
+        feature_dir,
+        orphan_runs,
+    })
+}
+
+/// Remove every artifact in the given `OrphanState`. Best-effort: logs and
+/// skips on per-entry errors. Removes the spec dir, `.specify/feature.json`,
+/// and any orphan workflow-run dirs. Does NOT touch git branches.
+pub fn clean(repo: &Path, state: &OrphanState) -> std::io::Result<()> {
+    if state.feature_dir.exists() {
+        std::fs::remove_dir_all(&state.feature_dir)?;
+    }
+    let feature_json = repo.join(".specify").join("feature.json");
+    if feature_json.exists() {
+        std::fs::remove_file(&feature_json)?;
+    }
+    for run in &state.orphan_runs {
+        if run.exists() {
+            std::fs::remove_dir_all(run)?;
+        }
+    }
+    // If specs/ is now empty, remove it (matches pre-orphan state on a
+    // fixture that had no specs/ before the aborted workflow run).
+    let specs_root = repo.join("specs");
+    if specs_root.is_dir() {
+        if let Ok(mut it) = std::fs::read_dir(&specs_root) {
+            if it.next().is_none() {
+                let _ = std::fs::remove_dir(&specs_root);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn parse_feature_directory(raw: &str) -> Option<String> {
+    // Dependency-free parse: look for `"feature_directory":"<value>"`.
+    let key = "\"feature_directory\"";
+    let start = raw.find(key)? + key.len();
+    let rest = &raw[start..];
+    let colon = rest.find(':')?;
+    let after_colon = &rest[colon + 1..];
+    let quote1 = after_colon.find('"')?;
+    let after_q1 = &after_colon[quote1 + 1..];
+    let quote2 = after_q1.find('"')?;
+    Some(after_q1[..quote2].to_string())
+}
+
+fn spec_md_is_template(path: &Path) -> bool {
+    let text = match std::fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+    // Look in the first 20 lines for any of the template-placeholder markers.
+    let probe: String = text.lines().take(20).collect::<Vec<_>>().join("\n");
+    probe.contains("[FEATURE NAME]") || probe.contains("[###-feature-name]")
+}

--- a/crates/specere-units/src/speckit.rs
+++ b/crates/specere-units/src/speckit.rs
@@ -99,6 +99,17 @@ impl AddUnit for Speckit {
     }
 
     fn preflight(&self, ctx: &Ctx) -> Result<Plan> {
+        // Issue #16: refuse on orphan .specify/ state before any other work.
+        if let Some(state) = crate::orphan::detect(ctx.repo()) {
+            return Err(specere_core::Error::OrphanFeatureDir {
+                feature_dir: state
+                    .feature_dir
+                    .strip_prefix(ctx.repo())
+                    .map(|p| p.to_path_buf())
+                    .unwrap_or(state.feature_dir),
+            });
+        }
+
         let mut plan = Plan::default();
         if !test_skip_uvx() && !command_exists("uvx") && !command_exists("specify") {
             return Err(specere_core::Error::Preflight(

--- a/crates/specere/src/main.rs
+++ b/crates/specere/src/main.rs
@@ -61,7 +61,12 @@ enum Command {
     /// Re-hash every manifest entry and report drift.
     Verify,
     /// Diagnose the target repo (installed units, tool prerequisites).
-    Doctor,
+    Doctor {
+        /// Sweep orphan `.specify/` state left by aborted
+        /// `specify workflow run` subprocesses (issue #16).
+        #[arg(long)]
+        clean_orphans: bool,
+    },
     /// Emit telemetry records from a hook invocation.
     Observe,
 }
@@ -100,7 +105,23 @@ fn main() -> Result<()> {
         } => specere_units::remove(&ctx, &unit, ctx.dry_run(), force, delete_branch),
         Command::Status => specere_units::status(&ctx),
         Command::Verify => specere_units::verify(&ctx),
-        Command::Doctor => specere_units::doctor(&ctx),
+        Command::Doctor { clean_orphans } => {
+            if clean_orphans {
+                match specere_units::clean_orphans(&ctx) {
+                    Ok(0) => {
+                        println!("No orphan .specify/ state detected.");
+                        Ok(())
+                    }
+                    Ok(n) => {
+                        println!("Cleaned {n} orphan artifact group(s).");
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                }
+            } else {
+                specere_units::doctor(&ctx)
+            }
+        }
         Command::Observe => specere_telemetry::observe(&ctx),
     };
 

--- a/crates/specere/tests/fr_p2_orphan_detector.rs
+++ b/crates/specere/tests/fr_p2_orphan_detector.rs
@@ -1,0 +1,114 @@
+//! Issue #16 — `speckit::preflight` refuses over an orphan `.specify/`
+//! artifact left behind by an aborted `specify workflow run`. `specere doctor
+//! --clean-orphans` sweeps the artifact.
+
+mod common;
+
+use common::TempRepo;
+
+/// Fabricate the exact state observed on 2026-04-18: `.specify/feature.json`
+/// points at a `specs/NNN-.../` dir whose `spec.md` is still the unfilled
+/// template (i.e. contains `[FEATURE NAME]`).
+fn fabricate_orphan(repo: &TempRepo) {
+    repo.write(
+        ".specify/feature.json",
+        r#"{"feature_directory":"specs/001-ghost"}"#,
+    );
+    repo.write(
+        "specs/001-ghost/spec.md",
+        "# Feature Specification: [FEATURE NAME]\n\n**Feature Branch**: `[###-feature-name]`\n",
+    );
+}
+
+#[test]
+fn preflight_refuses_on_orphan_specify_state() {
+    let repo = TempRepo::new();
+    fabricate_orphan(&repo);
+
+    let out = repo
+        .run_specere(&["--dry-run", "add", "speckit"])
+        .env("SPECERE_TEST_SKIP_UVX", "1")
+        .output()
+        .expect("spawn");
+    assert!(
+        !out.status.success(),
+        "expected refuse on orphan state; got exit 0\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("orphan") || stderr.contains("Orphan"),
+        "stderr should mention orphan; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("doctor"),
+        "stderr should cite `specere doctor --clean-orphans`; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn clean_orphans_removes_fabricated_state() {
+    let repo = TempRepo::new();
+    fabricate_orphan(&repo);
+
+    let out = repo
+        .run_specere(&["doctor", "--clean-orphans"])
+        .output()
+        .expect("spawn");
+    assert!(
+        out.status.success(),
+        "clean-orphans failed — exit {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(
+        !repo.abs("specs/001-ghost").exists(),
+        "orphan spec dir not removed"
+    );
+    assert!(
+        !repo.abs(".specify/feature.json").exists(),
+        "orphan feature.json not removed"
+    );
+}
+
+#[test]
+fn non_orphan_spec_preserved() {
+    // A real feature dir: spec.md with `[FEATURE NAME]` replaced.
+    let repo = TempRepo::new();
+    repo.write(
+        ".specify/feature.json",
+        r#"{"feature_directory":"specs/001-real-feature"}"#,
+    );
+    repo.write(
+        "specs/001-real-feature/spec.md",
+        "# Feature Specification: Real Feature\n\nContent.\n",
+    );
+    let out = repo
+        .run_specere(&["doctor", "--clean-orphans"])
+        .output()
+        .expect("spawn");
+    assert!(
+        out.status.success(),
+        "doctor should succeed on non-orphan state"
+    );
+    // Critical: real content preserved.
+    assert!(repo.abs("specs/001-real-feature/spec.md").exists());
+    assert!(repo.abs(".specify/feature.json").exists());
+}
+
+#[test]
+fn no_specify_state_at_all_passes_clean() {
+    let repo = TempRepo::new();
+    // No .specify/ or specs/ at all — doctor must not error.
+    let out = repo
+        .run_specere(&["doctor", "--clean-orphans"])
+        .output()
+        .expect("spawn");
+    assert!(
+        out.status.success(),
+        "doctor should succeed when there's no state\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #16. Second sub-issue of Phase 2 per [\`docs/phase2-execution-plan.md\`](../blob/main/docs/phase2-execution-plan.md) linear order (#12 → **#16** → #13 → #14 → #15).

Closes the carry-over from 2026-04-18's \`.specere/decisions.log\` EXTEND: aborted \`specify workflow run\` subprocesses leave ghost feature-dir state that subsequent \`specere add speckit\` would silently compound.

## Design

**Heuristic:** \`.specify/feature.json\` references a \`specs/NNN-*/\` dir whose \`spec.md\` still contains \`[FEATURE NAME]\` or \`[###-feature-name]\` template placeholders. This is the exact fingerprint of an aborted \`/speckit-specify\` invocation.

**Preflight integration:** \`Speckit::preflight\` runs orphan detection as step 1 — before any \`uvx\`/\`specify\` lookup — so the error surfaces immediately with an actionable help pointer.

**Sweeping:** \`specere doctor --clean-orphans\` removes the spec dir + \`.specify/feature.json\` + any orphan \`.specify/workflows/runs/*/\` dirs. Removes empty \`specs/\` root too. **Does not touch git branches** — user runs \`git branch -D\` directly if needed. Lower blast radius.

## Files

- \`crates/specere-units/src/orphan.rs\` (new, ~80 LoC) — pure \`detect\` + \`clean\` on a repo path.
- \`crates/specere-core/src/lib.rs\` — \`Error::OrphanFeatureDir\` variant, exit code 8.
- \`crates/specere-units/src/speckit.rs\` — preflight gains orphan detection as first step.
- \`crates/specere-units/src/lib.rs\` — \`pub mod orphan;\` + \`clean_orphans(ctx)\` helper.
- \`crates/specere/src/main.rs\` — \`Command::Doctor { clean_orphans: bool }\`.
- \`crates/specere/tests/fr_p2_orphan_detector.rs\` (new, 4 scenarios).

## Test plan

- [x] \`cargo test --workspace --all-targets\`: **54/54** (was 50).
- [x] \`cargo clippy -- -D warnings\`: clean.
- [x] \`cargo fmt --check\`: clean.
- [ ] CI gates (\`rustfmt\` · \`clippy\` · \`test × 3 OS\` · \`docs-sync\` · \`review\`).

## Regression scenarios

Critical: **non-orphan spec preserved** (false-positive safety). \`fr_p2_orphan_detector.rs\` covers:

1. Preflight refuses on fabricated orphan with exit ≠ 0 + stderr naming \"orphan\" + \"doctor\".
2. \`doctor --clean-orphans\` removes the fabricated state.
3. Non-orphan spec (placeholder replaced) is preserved — critical.
4. No \`.specify/\` state at all passes cleanly.

## Plan re-check (§5)

- Test count: estimate 4, delivered 4. ✅
- Scope: ~80 LoC impl + 90 LoC tests. Well under 500. ✅
- Contract changes: new \`Error\` variant only (additive). ✅
- Novel review-queue items: none observed. ✅

**No re-plan triggers. Next after merge: #13 otel-collector.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)