### PR TITLE
feat(filter): specere-filter crate + PerSpecHMM baseline (issue #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to SpecERE will be documented here. The format follows [Keep
 
 ## [Unreleased]
 
+### Added (Phase 4)
+- **`specere-filter` crate scaffold + `PerSpecHMM` baseline** (issue #40 / pre-FR-P4-001..006). New workspace member `crates/specere-filter/` (dep: `ndarray = 0.16`) with the three-state simplex `Status::{Unk, Sat, Vio}`, a `TestSensor` trait for log-likelihood emissions, a prototype-ported `Motion` model (`t_good`, `t_bad`, `t_leak` + `assumed_good=0.7`), and an independent per-spec forward recursion. `predict()` advances touched specs via the mixture transition and untouched specs via identity-leak; `update_test()` runs Bayes in log space with a log-sum-exp stabiliser. 9 new tests total: 5 unit (motion row-stochasticity, predict simplex invariance, touched-vs-untouched asymmetry, construction prior) + 4 integration (uniform+pass matches closed-form, predict+pass matches hand-computed posterior, unknown-spec rejection, 100-event no-NaN smoke). Phase 4 execution plan at `docs/phase4-execution-plan.md`.
+
 ### Added (Phase 3)
 - **`specere serve` OTLP/gRPC receiver** (issue #34 / FR-P3-001 closure). Tonic-based gRPC receiver on `127.0.0.1:4317` (port configurable via `.specere/otel-config.yml → receivers.otlp.protocols.grpc.endpoint` or `--grpc-bind`). Implements `TraceServiceServer` + `LogsServiceServer` from `opentelemetry-proto` 0.31 (`gen-tonic` feature); each span / log record becomes one Event written to the shared SQLite connection. New public `serve_both` runs HTTP + gRPC concurrently over one `Arc<Mutex<rusqlite::Connection>>`, with SIGINT fan-out via `tokio::sync::watch`. CLI: `specere serve --grpc-bind 127.0.0.1:4317` parallels `--bind`. Dev-deps bump: `tonic = "0.14"`, `opentelemetry-proto = "0.31"`, `prost = "0.14"`, `tokio-stream = "0.1"`. 2 new integration tests in `crates/specere/tests/fr_p3_005_serve_grpc.rs` (end-to-end `ExportTraceServiceRequest` round-trip + graceful shutdown).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1021,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1035,6 +1054,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,10 +1084,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1159,6 +1211,21 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1384,6 +1451,12 @@ checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "regex"
@@ -1742,6 +1815,16 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
  "tracing",
+]
+
+[[package]]
+name = "specere-filter"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "approx",
+ "ndarray",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/specere-manifest",
     "crates/specere-markers",
     "crates/specere-telemetry",
+    "crates/specere-filter",
 ]
 
 [workspace.package]
@@ -45,12 +46,14 @@ tonic = { version = "0.14", features = ["transport"] }
 opentelemetry-proto = { version = "0.31", features = ["gen-tonic", "trace", "logs"] }
 prost = "0.14"
 tokio-stream = { version = "0.1", features = ["net"] }
+ndarray = "0.16"
 
 specere-core = { path = "crates/specere-core", version = "0.2.0" }
 specere-units = { path = "crates/specere-units", version = "0.2.0" }
 specere-manifest = { path = "crates/specere-manifest", version = "0.2.0" }
 specere-markers = { path = "crates/specere-markers", version = "0.2.0" }
 specere-telemetry = { path = "crates/specere-telemetry", version = "0.2.0" }
+specere-filter = { path = "crates/specere-filter", version = "0.2.0" }
 
 [profile.release]
 lto = "thin"

--- a/crates/specere-filter/Cargo.toml
+++ b/crates/specere-filter/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "specere-filter"
+description = "SpecERE per-spec HMM / factor-graph BP / RBPF filter over the event store"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+ndarray.workspace = true
+serde.workspace = true
+
+[dev-dependencies]
+approx = "0.5"

--- a/crates/specere-filter/src/hmm.rs
+++ b/crates/specere-filter/src/hmm.rs
@@ -1,0 +1,213 @@
+//! `PerSpecHMM` — independent per-spec forward recursion. Mirrors the
+//! prototype's baseline filter (no cross-spec coupling; that lands in #41).
+//!
+//! Belief state: one length-3 simplex per spec, stored row-wise in an
+//! `Array2<f64>` indexed by [`crate::Status`] columns. All updates are
+//! log-domain-safe — `update_test` runs Bayes in log space with a stable
+//! log-sum-exp normalisation, and `predict` normalises rows defensively
+//! because numerical drift across long motion chains can push row-sums
+//! slightly off unity.
+
+use std::collections::HashMap;
+
+use anyhow::{anyhow, Result};
+use ndarray::{Array1, Array2};
+
+use crate::motion::Motion;
+use crate::state::{Belief, TestSensor};
+
+const EPS: f64 = 1e-12;
+
+/// A single spec plus the set of files whose edits should advance its belief.
+#[derive(Debug, Clone)]
+pub struct SpecDescriptor {
+    pub id: String,
+    /// File paths (or prefixes — caller's contract) that imply this spec
+    /// when touched by an agent write.
+    pub support: Vec<String>,
+}
+
+/// Baseline per-spec Bayesian filter. Beliefs are held in an `Array2<f64>`
+/// of shape `(n_specs, 3)`; each row is a simplex over [`crate::Status`].
+pub struct PerSpecHMM {
+    spec_ids: Vec<String>,
+    idx: HashMap<String, usize>,
+    support: Vec<Vec<String>>,
+    motion: Motion,
+    belief: Array2<f64>,
+}
+
+impl PerSpecHMM {
+    /// Build with uniform 1/3-1/3-1/3 priors on every spec.
+    pub fn new(specs: Vec<SpecDescriptor>, motion: Motion) -> Self {
+        let n = specs.len();
+        let mut spec_ids = Vec::with_capacity(n);
+        let mut idx = HashMap::with_capacity(n);
+        let mut support = Vec::with_capacity(n);
+        for (i, s) in specs.into_iter().enumerate() {
+            idx.insert(s.id.clone(), i);
+            spec_ids.push(s.id);
+            support.push(s.support);
+        }
+        let belief = Array2::from_elem((n, 3), 1.0 / 3.0);
+        Self {
+            spec_ids,
+            idx,
+            support,
+            motion,
+            belief,
+        }
+    }
+
+    pub fn spec_ids(&self) -> &[String] {
+        &self.spec_ids
+    }
+
+    pub fn num_specs(&self) -> usize {
+        self.spec_ids.len()
+    }
+
+    /// Return the current belief for one spec as a length-3 vector
+    /// `[p(Unk), p(Sat), p(Vio)]`. Errors if the id is unknown.
+    pub fn marginal(&self, spec_id: &str) -> Result<Belief> {
+        let i = self
+            .idx
+            .get(spec_id)
+            .ok_or_else(|| anyhow!("unknown spec id: {spec_id}"))?;
+        Ok(self.belief.row(*i).to_owned())
+    }
+
+    /// Return the full belief matrix (n_specs × 3) as a fresh owned copy.
+    pub fn all_marginals(&self) -> Array2<f64> {
+        self.belief.clone()
+    }
+
+    /// Motion step. For each spec, if any of its support files intersects
+    /// `files_touched`, advance its row by the mixture transition
+    /// `t_mix = α·t_good + (1-α)·t_bad`; otherwise by the identity-leak
+    /// `t_leak`. Each row is renormalised defensively — the underlying
+    /// matrices are row-stochastic so the sum should already be 1, but
+    /// long motion chains accumulate float drift.
+    pub fn predict(&mut self, files_touched: &[&str]) {
+        let t_mix = self.motion.t_mix();
+        let t_leak = &self.motion.t_leak;
+        for i in 0..self.spec_ids.len() {
+            let touched = self.support[i]
+                .iter()
+                .any(|p| files_touched.iter().any(|f| f == p));
+            let m = if touched { &t_mix } else { t_leak };
+            let row = self.belief.row(i).to_owned();
+            let next = row.dot(m);
+            self.belief.row_mut(i).assign(&normalise(&next));
+        }
+    }
+
+    /// Observation step for a test outcome. Multiplies the current belief
+    /// by the sensor's log-likelihood in log space, then renormalises via
+    /// log-sum-exp. Unknown spec ids return an error — callers should
+    /// either ignore stray events or declare the spec first.
+    pub fn update_test<S: TestSensor>(
+        &mut self,
+        spec_id: &str,
+        outcome: &str,
+        sensor: &S,
+    ) -> Result<()> {
+        let i = self
+            .idx
+            .get(spec_id)
+            .ok_or_else(|| anyhow!("unknown spec id: {spec_id}"))?;
+        let prior = self.belief.row(*i).to_owned();
+        let log_lik = sensor.log_likelihood(spec_id, outcome);
+        debug_assert_eq!(log_lik.len(), 3, "TestSensor must return a length-3 vector");
+        let mut log_post: Array1<f64> = prior.mapv(|p| (p + EPS).ln()) + &log_lik;
+        let m = log_post.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        log_post.mapv_inplace(|x| x - m);
+        let post = log_post.mapv(f64::exp);
+        let total = post.sum();
+        let next = if total > EPS {
+            post / total
+        } else {
+            Array1::from_elem(3, 1.0 / 3.0)
+        };
+        self.belief.row_mut(*i).assign(&next);
+        Ok(())
+    }
+}
+
+fn normalise(v: &Array1<f64>) -> Array1<f64> {
+    let total = v.sum();
+    if total > EPS {
+        v / total
+    } else {
+        Array1::from_elem(v.len(), 1.0 / v.len() as f64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uniform_prior_sums_to_one_on_construction() {
+        let specs = vec![SpecDescriptor {
+            id: "FR-001".into(),
+            support: vec!["src/foo.rs".into()],
+        }];
+        let f = PerSpecHMM::new(specs, Motion::prototype_defaults());
+        let m = f.marginal("FR-001").unwrap();
+        assert!((m.sum() - 1.0).abs() < 1e-12);
+        assert_eq!(m.len(), 3);
+    }
+
+    #[test]
+    fn predict_leaves_rows_on_simplex() {
+        let specs = vec![
+            SpecDescriptor {
+                id: "FR-001".into(),
+                support: vec!["src/foo.rs".into()],
+            },
+            SpecDescriptor {
+                id: "FR-002".into(),
+                support: vec!["src/bar.rs".into()],
+            },
+        ];
+        let mut f = PerSpecHMM::new(specs, Motion::prototype_defaults());
+        f.predict(&["src/foo.rs"]);
+        for i in 0..f.num_specs() {
+            let row = f.all_marginals().row(i).to_owned();
+            assert!(
+                (row.sum() - 1.0).abs() < 1e-9,
+                "row {i} off simplex: sum = {}",
+                row.sum()
+            );
+        }
+    }
+
+    #[test]
+    fn predict_only_moves_touched_specs() {
+        let specs = vec![
+            SpecDescriptor {
+                id: "FR-001".into(),
+                support: vec!["src/foo.rs".into()],
+            },
+            SpecDescriptor {
+                id: "FR-002".into(),
+                support: vec!["src/bar.rs".into()],
+            },
+        ];
+        let mut f = PerSpecHMM::new(specs, Motion::prototype_defaults());
+        let before = f.marginal("FR-002").unwrap();
+        f.predict(&["src/foo.rs"]);
+        let after_foo = f.marginal("FR-001").unwrap();
+        let after_bar = f.marginal("FR-002").unwrap();
+        // FR-002 wasn't touched — only the tiny identity-leak moved it. Its
+        // deviation from the uniform prior must be strictly smaller than
+        // FR-001's (which got the full mix transition).
+        let delta_bar = (&after_bar - &before).mapv(f64::abs).sum();
+        let delta_foo = (&after_foo - &before).mapv(f64::abs).sum();
+        assert!(
+            delta_foo > 10.0 * delta_bar,
+            "touched/untouched ratio too small: foo Δ={delta_foo}, bar Δ={delta_bar}"
+        );
+    }
+}

--- a/crates/specere-filter/src/lib.rs
+++ b/crates/specere-filter/src/lib.rs
@@ -1,0 +1,24 @@
+//! Per-spec Bayesian filter over agent-telemetry events.
+//!
+//! Phase 4 / issue #40 — the baseline `PerSpecHMM` forward recursion. Takes
+//! a [`Motion`] model (transition matrices ported verbatim from the ReSearch
+//! prototype) and a per-spec belief over the three-state simplex
+//! [`Status::Unk`], [`Status::Sat`], [`Status::Vio`], and advances it in two
+//! ways:
+//!
+//! - [`PerSpecHMM::predict`] — motion step from an agent write; specs whose
+//!   support files were touched get the mixture transition, the rest get
+//!   the identity-leak.
+//! - [`PerSpecHMM::update_test`] — observation step from a test outcome;
+//!   Bayes in log-domain against a caller-supplied emission likelihood.
+//!
+//! Issues #41 (FactorGraphBP) and #42 (RBPF) extend this baseline; issue #43
+//! wires the CLI. Hyperparameters match `prototype/mini_specs/filter.py`.
+
+pub mod hmm;
+pub mod motion;
+pub mod state;
+
+pub use hmm::PerSpecHMM;
+pub use motion::Motion;
+pub use state::{Belief, Status, TestSensor};

--- a/crates/specere-filter/src/motion.rs
+++ b/crates/specere-filter/src/motion.rs
@@ -1,0 +1,79 @@
+//! Transition matrices for the motion step. Ported from
+//! `prototype/mini_specs/filter.py` + `prototype/mini_specs/world.py`.
+//! These are Gate-A-validated starting values; do not re-tune without a new
+//! parity export against the Python prototype.
+
+use ndarray::{array, Array2};
+
+/// Three 3×3 transition matrices + the `assumed_good_rate` that mixes the
+/// "good write" and "bad write" models when a spec's support file is touched.
+/// Untouched specs use the identity-leak matrix (nearly identity, small
+/// drift toward UNK to model clock-independent uncertainty).
+#[derive(Debug, Clone)]
+pub struct Motion {
+    /// Transition when a "good" write lands on a supporting file.
+    pub t_good: Array2<f64>,
+    /// Transition when a "bad" write lands on a supporting file.
+    pub t_bad: Array2<f64>,
+    /// Transition when no supporting file was touched (identity + leak).
+    pub t_leak: Array2<f64>,
+    /// Mixing weight on `t_good` for the touched case.
+    /// Mix: `assumed_good * t_good + (1 - assumed_good) * t_bad`.
+    pub assumed_good: f64,
+}
+
+impl Motion {
+    /// Prototype defaults. Rows are current-status, columns next-status.
+    /// Order is [UNK, SAT, VIO] — matches [`crate::Status::index`].
+    pub fn prototype_defaults() -> Self {
+        // Good write: strong pull toward SAT; small chance of a latent VIO.
+        let t_good = array![[0.20, 0.75, 0.05], [0.05, 0.93, 0.02], [0.10, 0.70, 0.20],];
+        // Bad write: pull toward VIO; UNK tends to stay or drift to VIO.
+        let t_bad = array![[0.25, 0.15, 0.60], [0.05, 0.40, 0.55], [0.05, 0.05, 0.90],];
+        // Identity-leak: nearly identity, a 1% drift toward UNK on Sat/Vio
+        // so old beliefs age toward uncertainty.
+        let t_leak = array![[0.98, 0.01, 0.01], [0.01, 0.98, 0.01], [0.01, 0.01, 0.98],];
+        Self {
+            t_good,
+            t_bad,
+            t_leak,
+            assumed_good: 0.7,
+        }
+    }
+
+    /// `assumed_good * t_good + (1 - assumed_good) * t_bad`.
+    pub fn t_mix(&self) -> Array2<f64> {
+        &self.t_good * self.assumed_good + &self.t_bad * (1.0 - self.assumed_good)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rows_sum_to_one(m: &Array2<f64>) -> bool {
+        m.rows().into_iter().all(|r| (r.sum() - 1.0).abs() < 1e-9)
+    }
+
+    #[test]
+    fn prototype_matrices_are_row_stochastic() {
+        let m = Motion::prototype_defaults();
+        assert!(rows_sum_to_one(&m.t_good), "t_good rows must sum to 1");
+        assert!(rows_sum_to_one(&m.t_bad), "t_bad rows must sum to 1");
+        assert!(rows_sum_to_one(&m.t_leak), "t_leak rows must sum to 1");
+        assert!(rows_sum_to_one(&m.t_mix()), "t_mix rows must sum to 1");
+    }
+
+    #[test]
+    fn mix_at_full_good_equals_t_good() {
+        let mut m = Motion::prototype_defaults();
+        m.assumed_good = 1.0;
+        let mix = m.t_mix();
+        let diff = (&mix - &m.t_good)
+            .mapv(f64::abs)
+            .iter()
+            .cloned()
+            .fold(0.0_f64, f64::max);
+        assert!(diff < 1e-12, "mix diverged from t_good by {diff}");
+    }
+}

--- a/crates/specere-filter/src/state.rs
+++ b/crates/specere-filter/src/state.rs
@@ -1,0 +1,39 @@
+//! 3-state simplex over spec statuses + the per-spec [`Belief`] vector + the
+//! [`TestSensor`] trait that callers implement to feed observation-likelihoods
+//! into [`crate::PerSpecHMM::update_test`].
+
+use ndarray::Array1;
+
+/// Spec status space. Matches the prototype's indexing — `Unk = 0`, `Sat = 1`,
+/// `Vio = 2`. Do not reorder without updating every hand-computed fixture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Status {
+    Unk = 0,
+    Sat = 1,
+    Vio = 2,
+}
+
+impl Status {
+    pub fn index(self) -> usize {
+        self as usize
+    }
+}
+
+/// Per-spec belief — length-3 simplex normalised to sum to 1. Order follows
+/// [`Status::index`].
+pub type Belief = Array1<f64>;
+
+/// Uniform 1/3-1/3-1/3 prior.
+pub fn uniform_belief() -> Belief {
+    Array1::from_elem(3, 1.0 / 3.0)
+}
+
+/// Emission model for a test outcome. Implementations return the log-likelihood
+/// of the observed outcome conditional on each spec status (length-3 vector
+/// indexed by [`Status`]). Keep it cheap — this is called once per
+/// [`crate::PerSpecHMM::update_test`] call.
+pub trait TestSensor {
+    /// `log p(outcome | status)` for the three spec statuses.
+    fn log_likelihood(&self, spec_id: &str, outcome: &str) -> Array1<f64>;
+}

--- a/crates/specere-filter/tests/perspec_hmm_hand_computed.rs
+++ b/crates/specere-filter/tests/perspec_hmm_hand_computed.rs
@@ -1,0 +1,111 @@
+//! Hand-computed 2-event fixture. The expected numbers are reproduced with
+//! `numpy` on the same `Motion::prototype_defaults()` matrices so this test
+//! is the exact parity anchor for #40. If any of these numbers drift, the
+//! motion matrices or the log-domain renormalisation has changed.
+
+use approx::assert_abs_diff_eq;
+use ndarray::{array, Array1};
+use specere_filter::hmm::SpecDescriptor;
+use specere_filter::{Motion, PerSpecHMM, TestSensor};
+
+/// Deterministic test sensor: `outcome="pass"` → log-likelihood [ln 0.10, ln 0.80, ln 0.10];
+/// `outcome="fail"` → log-likelihood [ln 0.30, ln 0.10, ln 0.60]. Matches a
+/// typical "clean test pass pushes belief toward SAT, failure toward VIO"
+/// shape. These numbers are baked into the hand-computed expected posterior.
+struct DemoSensor;
+impl TestSensor for DemoSensor {
+    fn log_likelihood(&self, _spec_id: &str, outcome: &str) -> Array1<f64> {
+        match outcome {
+            "pass" => array![0.10_f64.ln(), 0.80_f64.ln(), 0.10_f64.ln()],
+            "fail" => array![0.30_f64.ln(), 0.10_f64.ln(), 0.60_f64.ln()],
+            other => panic!("unexpected outcome: {other}"),
+        }
+    }
+}
+
+fn one_spec() -> Vec<SpecDescriptor> {
+    vec![SpecDescriptor {
+        id: "FR-001".into(),
+        support: vec!["src/foo.rs".into()],
+    }]
+}
+
+#[test]
+fn uniform_prior_plus_pass_matches_bayes_closed_form() {
+    // With a uniform (1/3, 1/3, 1/3) prior and sensor row [0.10, 0.80, 0.10],
+    // the posterior is [0.10, 0.80, 0.10] (uniform prior cancels).
+    let mut f = PerSpecHMM::new(one_spec(), Motion::prototype_defaults());
+    f.update_test("FR-001", "pass", &DemoSensor).unwrap();
+    let m = f.marginal("FR-001").unwrap();
+    let expected = array![0.10, 0.80, 0.10];
+    assert_abs_diff_eq!(m[0], expected[0], epsilon = 1e-9);
+    assert_abs_diff_eq!(m[1], expected[1], epsilon = 1e-9);
+    assert_abs_diff_eq!(m[2], expected[2], epsilon = 1e-9);
+}
+
+#[test]
+fn predict_then_pass_matches_hand_computed() {
+    // Step 1: predict on a touched file. Uniform prior (1/3, 1/3, 1/3) times
+    // t_mix = 0.7·t_good + 0.3·t_bad. Row-stochastic matrices → the
+    // row-sum-over-columns is (col-sum)/3 for each column.
+    //
+    // t_mix column sums (computed by hand from prototype_defaults):
+    //   col 0 (UNK): 0.7·(0.20+0.05+0.10) + 0.3·(0.25+0.05+0.05)
+    //              = 0.7·0.35 + 0.3·0.35 = 0.35
+    //   col 1 (SAT): 0.7·(0.75+0.93+0.70) + 0.3·(0.15+0.40+0.05)
+    //              = 0.7·2.38 + 0.3·0.60 = 1.666 + 0.18 = 1.846
+    //   col 2 (VIO): 0.7·(0.05+0.02+0.20) + 0.3·(0.60+0.55+0.90)
+    //              = 0.7·0.27 + 0.3·2.05 = 0.189 + 0.615 = 0.804
+    // Divide each by 3 for the uniform-row contraction:
+    //   post-predict prior ≈ [0.11667, 0.61533, 0.26800]
+    let mut f = PerSpecHMM::new(one_spec(), Motion::prototype_defaults());
+    f.predict(&["src/foo.rs"]);
+    let after_predict = f.marginal("FR-001").unwrap();
+    assert_abs_diff_eq!(after_predict[0], 0.35 / 3.0, epsilon = 1e-9);
+    assert_abs_diff_eq!(after_predict[1], 1.846 / 3.0, epsilon = 1e-9);
+    assert_abs_diff_eq!(after_predict[2], 0.804 / 3.0, epsilon = 1e-9);
+
+    // Step 2: update on "pass" — log-domain Bayes with sensor [0.10, 0.80, 0.10].
+    // Un-normalised posterior:
+    //   [0.11667·0.10, 0.61533·0.80, 0.26800·0.10]
+    // = [0.011667,     0.492267,     0.026800]
+    // total = 0.530733 → posterior ≈ [0.02199, 0.92752, 0.05049]
+    f.update_test("FR-001", "pass", &DemoSensor).unwrap();
+    let post = f.marginal("FR-001").unwrap();
+    let un_norm = [
+        (0.35 / 3.0) * 0.10,
+        (1.846 / 3.0) * 0.80,
+        (0.804 / 3.0) * 0.10,
+    ];
+    let total: f64 = un_norm.iter().sum();
+    assert_abs_diff_eq!(post[0], un_norm[0] / total, epsilon = 1e-9);
+    assert_abs_diff_eq!(post[1], un_norm[1] / total, epsilon = 1e-9);
+    assert_abs_diff_eq!(post[2], un_norm[2] / total, epsilon = 1e-9);
+    // Sanity: the posterior must be a valid simplex.
+    assert_abs_diff_eq!(post.sum(), 1.0, epsilon = 1e-9);
+}
+
+#[test]
+fn update_test_rejects_unknown_spec() {
+    let mut f = PerSpecHMM::new(one_spec(), Motion::prototype_defaults());
+    let err = f.update_test("FR-999", "pass", &DemoSensor);
+    assert!(err.is_err(), "expected error for unknown spec");
+}
+
+#[test]
+fn hundred_event_stream_has_no_nan_and_sums_to_one() {
+    // FR-P4 smoke: no NaN/Inf, every row normalised within 1e-9. 100 events
+    // alternate predict + test on a single spec.
+    let mut f = PerSpecHMM::new(one_spec(), Motion::prototype_defaults());
+    for i in 0..100 {
+        f.predict(&["src/foo.rs"]);
+        let outcome = if i % 2 == 0 { "pass" } else { "fail" };
+        f.update_test("FR-001", outcome, &DemoSensor).unwrap();
+        let m = f.marginal("FR-001").unwrap();
+        for v in m.iter() {
+            assert!(v.is_finite(), "non-finite at step {i}: {v}");
+            assert!((0.0..=1.0).contains(v), "off simplex at step {i}: {v}");
+        }
+        assert_abs_diff_eq!(m.sum(), 1.0, epsilon = 1e-9);
+    }
+}


### PR DESCRIPTION
Closes #40. First sub-issue of Phase 4 parent #39.

## Summary

Introduces a new workspace member `crates/specere-filter/` with the baseline per-spec forward recursion — the foundation FactorGraphBP (#41), RBPF (#42), and the filter CLI (#43) build on.

- **`state.rs`** — 3-state simplex over `Status::{Unk, Sat, Vio}` + the `TestSensor` trait that callers implement to feed observation log-likelihoods. `Belief` = `ndarray::Array1<f64>`.
- **`motion.rs`** — three 3×3 transition matrices (`t_good`, `t_bad`, `t_leak`) + `assumed_good` mixing weight. Values ported verbatim from `prototype/mini_specs/filter.py` + `world.py` — Gate-A-validated priors per `docs/phase4-execution-plan.md` §2.
- **`hmm.rs`** — `PerSpecHMM` with `new`, `predict`, `update_test`, `marginal`, `all_marginals`. `predict()` advances touched specs by the mix matrix and untouched specs by identity-leak. `update_test()` runs Bayes in log space with a log-sum-exp stabiliser.
- **`lib.rs`** — re-exports the public surface.

## TDD anchors

`tests/perspec_hmm_hand_computed.rs` — four integration tests that bake the expected posteriors against the prototype's matrices:
- `uniform_prior_plus_pass_matches_bayes_closed_form` — uniform prior cancels, posterior = sensor row.
- `predict_then_pass_matches_hand_computed` — full hand-computed 2-event posterior, exact to 1e-9.
- `update_test_rejects_unknown_spec` — error path.
- `hundred_event_stream_has_no_nan_and_sums_to_one` — smoke: 100 alternating predict/update steps, every row remains a valid simplex.

## Out of scope

- Factor-graph BP / coupling graph loader / cycle detection (→ #41).
- RBPF + Gate-A parity export (→ #42).
- `specere filter run / status` CLI + atomic posterior write (→ #43).

## Test plan

- [x] `cargo test --package specere-filter` — 5 unit + 4 integration pass.
- [x] `cargo test --workspace --all-targets` — 110 total pass (101 before + 9 new).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [ ] CI (linux/macos/windows) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)