### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to SpecERE will be documented here. The format follows [Keep
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-18
+
+First release with a live filter engine. Closes Phase 3 (observe pipeline) and Phase 4 (filter engine) main tracks plus the phase-4-follow-ups (Python-prototype parity + throughput).
+
 ### Added (Phase 4 follow-ups — FR-P4-002 + FR-P4-005)
 - **Gate-A Python-prototype parity test** (FR-P4-002 closure). New `scripts/export_gate_a_posterior.py` dumps a 324-event trace + expected beliefs from the ReSearch prototype into `crates/specere-filter/tests/fixtures/gate_a/posterior.toml` (one-time export; commit and re-pin only when algorithmic priors change). New integration test `crates/specere-filter/tests/gate_a_parity.rs` replays the trace through Rust `PerSpecHMM` and asserts per-cell absolute difference < 0.02 vs the prototype's final beliefs. Observed max cell diff on this laptop: **0.000000** — Rust output is bit-identical to Python at the fixture's precision.
 - **`Motion::prototype_defaults` + `DefaultTestSensor` aligned to prototype** (FR-P4-002 prerequisite). Transition matrices now match `ReSearch/prototype/mini_specs/world.py::build_demo_world` (`t_good`, `t_bad`, `t_leak`) verbatim. `DefaultTestSensor` uses the prototype's `alpha_sat=0.92, alpha_vio=0.90, alpha_unk=0.55` constants with the same 1e-6 log-floor. Hand-computed test expectations in `perspec_hmm_hand_computed.rs` updated to the new matrices.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "specere"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "specere-core"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "specere-filter"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "specere-manifest"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "specere-markers"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "serde_yaml",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "specere-telemetry"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "specere-units"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.78"
 authors = ["laiadlotape"]
@@ -49,12 +49,12 @@ tokio-stream = { version = "0.1", features = ["net"] }
 ndarray = "0.16"
 rand = "0.8"
 
-specere-core = { path = "crates/specere-core", version = "0.2.0" }
-specere-units = { path = "crates/specere-units", version = "0.2.0" }
-specere-manifest = { path = "crates/specere-manifest", version = "0.2.0" }
-specere-markers = { path = "crates/specere-markers", version = "0.2.0" }
-specere-telemetry = { path = "crates/specere-telemetry", version = "0.2.0" }
-specere-filter = { path = "crates/specere-filter", version = "0.2.0" }
+specere-core = { path = "crates/specere-core", version = "0.4.0" }
+specere-units = { path = "crates/specere-units", version = "0.4.0" }
+specere-manifest = { path = "crates/specere-manifest", version = "0.4.0" }
+specere-markers = { path = "crates/specere-markers", version = "0.4.0" }
+specere-telemetry = { path = "crates/specere-telemetry", version = "0.4.0" }
+specere-filter = { path = "crates/specere-filter", version = "0.4.0" }
 
 [profile.release]
 lto = "thin"


### PR DESCRIPTION
## Summary

Cuts **v0.4.0** — first release with a live filter engine.

### What's in this release

- **Phase 3 observe pipeline** (PRs #32–#38) — OTLP/HTTP on :4318 + OTLP/gRPC on :4317 + SQLite event store + 13 workflow-span hooks for every \`/speckit-*\` verb. FR-P3-001 through FR-P3-006 closed.
- **Phase 4 filter engine** (PRs #45–#49) — new \`specere-filter\` crate: PerSpecHMM baseline, FactorGraphBP overlay with coupling-graph DAG enforcement, RBPF escape valve with seeded determinism, and the \`specere filter run / status\` CLI with atomic posterior writes. FR-P4-001, FR-P4-003, FR-P4-004, FR-P4-006 closed.
- **Phase 4 follow-ups** (PR #51) — FR-P4-002 (< 2 pp Python-prototype parity on Gate-A; observed bit-identical), FR-P4-005 (≥ 1000 events/s; observed 15 166 events/s). Plus 5 manual-test findings fixed in-branch.

### Mechanics

- \`workspace.package.version\` bumped \`0.2.0\` → \`0.4.0\` (Phase 3 + Phase 4 both landed since 0.2.0; minor bump justified).
- All six workspace crate-dep entries bumped in lockstep.
- \`CHANGELOG.md\` \`[Unreleased]\` section moved to \`[0.4.0] - 2026-04-18\`; fresh empty \`[Unreleased]\` stub left.
- \`Cargo.lock\` refreshed via \`cargo build\`.

### What happens on merge + tag

1. This PR merges to main.
2. I push \`v0.4.0\` annotated tag on the merge commit.
3. \`release-guards.yml\` validates tag ↔ version ↔ CHANGELOG ↔ main-reachability (seconds).
4. \`release.yml\` (cargo-dist-generated) cross-compiles 5 targets, builds shell + powershell installers, attaches everything to the auto-created GitHub Release page (~15–20 min).

## Test plan

- [x] \`cargo build --workspace\` clean.
- [x] \`cargo test --workspace --all-targets\` — 156 pass.
- [ ] CI green.
- [ ] Post-merge: tag push → \`release-guards.yml\` green → \`release.yml\` attaches 5 binaries + 2 installers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)