### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to SpecERE will be documented here. The format follows [Keep
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-18
+
+Production-readiness release. First-run experience works end-to-end on a brand-new repo. Delivers Phase 5 partial (coupling-edge calibration from git log), closes issue #50 (advisory file-lock on `filter run`), ships `docs/filter.md`.
+
 ### Added (Phase 5 partial + v0.5.0 production polish)
 - **`specere calibrate from-git`** (Phase 5 partial). New subcommand that walks `git log`, tallies per-spec co-modification counts, and emits a ready-to-paste `[coupling]` TOML snippet for `.specere/sensor-map.toml`. Configurable via `--max-commits` (default 500) and `--min-commits` (default 3 — co-modifications below this are filtered as coincidences). Greedy DAG filter rejects proposed edges that would close a cycle. New crate module `specere-filter::calibrate` with 7 unit tests + 3 integration tests in `crates/specere/tests/fr_p5_calibrate_from_git.rs`. Dogfood on the specere repo surfaces the expected `cli ↔ units / telemetry / core` coupling. Motion-matrix fit (full FR-P5) deferred — needs a durable test-history source.
 - **Advisory file lock on `filter run`** (issue #50 closure). New workspace dep `fs2 = 0.4`. `run_filter_run` now acquires an exclusive lock on `.specere/filter.lock` before loading or writing the posterior; concurrent invocations queue instead of one losing the atomic-write race. Regression test `filter_run_serialises_concurrent_invocations`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "specere"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "specere-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "specere-filter"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "specere-manifest"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "specere-markers"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "serde_yaml",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "specere-telemetry"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "specere-units"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.78"
 authors = ["laiadlotape"]
@@ -50,12 +50,12 @@ ndarray = "0.16"
 rand = "0.8"
 fs2 = "0.4"
 
-specere-core = { path = "crates/specere-core", version = "0.4.0" }
-specere-units = { path = "crates/specere-units", version = "0.4.0" }
-specere-manifest = { path = "crates/specere-manifest", version = "0.4.0" }
-specere-markers = { path = "crates/specere-markers", version = "0.4.0" }
-specere-telemetry = { path = "crates/specere-telemetry", version = "0.4.0" }
-specere-filter = { path = "crates/specere-filter", version = "0.4.0" }
+specere-core = { path = "crates/specere-core", version = "0.5.0" }
+specere-units = { path = "crates/specere-units", version = "0.5.0" }
+specere-manifest = { path = "crates/specere-manifest", version = "0.5.0" }
+specere-markers = { path = "crates/specere-markers", version = "0.5.0" }
+specere-telemetry = { path = "crates/specere-telemetry", version = "0.5.0" }
+specere-filter = { path = "crates/specere-filter", version = "0.5.0" }
 
 [profile.release]
 lto = "thin"


### PR DESCRIPTION
Production-readiness release.

## What's in v0.5.0

- **Dogfood D-04 + D-05 blockers fixed** — `specere init` scaffolds work end-to-end on a fresh repo; `Posterior` deserialiser tolerant of older placeholder shapes.
- **Issue #50 closure** — advisory exclusive file lock on `.specere/filter.lock`; concurrent `filter run` invocations queue instead of racing.
- **`docs/filter.md`** — first end-user guide for the filter subcommand.
- **Phase 5 partial** — `specere calibrate from-git` coupling-edge suggester.

## Mechanics

- `workspace.package.version` 0.4.0 → 0.5.0.
- All six workspace crate-dep entries bumped in lockstep.
- CHANGELOG [Unreleased] → [0.5.0] - 2026-04-18.

## Test plan

- [x] 168 workspace tests green; clippy clean.
- [ ] CI cross-platform green.
- [ ] Tag push → release-guards → release.yml → 16 artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)