### PR TITLE
release: v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to SpecERE will be documented here. The format follows [Keep
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-04-19
+
+Closes Phase 4 parity gap. FR-P4-002 now fully satisfied across all three filter paths.
+
 ### Added (v1.0.2 prep)
 - **FactorGraphBP Gate-A parity** (closes #42). `crates/specere-filter/tests/gate_a_parity.rs::rust_factor_graph_bp_matches_gate_a_fixture_within_2pp` replays the fixture trace through Rust BP and asserts per-cell agreement with the Python prototype's `FactorGraphBP.all_marginals()`. Observed max cell diff: **0.000000** (bit-identical).
 - **RBPF Gate-A tail-MAP parity** (closes #42 remainder). `rust_rbpf_matches_gate_a_fixture_tail_map_within_2pp` asserts Rust RBPF's tail-MAP accuracy vs ground truth matches the prototype's within 2 pp (both are 5/8 on the Gate-A fixture). Per-cell RBPF probabilities diverge by more than 2 pp across languages because NumPy `default_rng` and Rust `StdRng` produce different uniform sequences from matched seeds — the divergence is PRNG drift, not algorithmic. FR-P4-002's 2 pp bound is a tail-MAP bound (what the spec actually says), not a per-cell bound.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "specere"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "specere-core"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "specere-filter"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "approx",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "specere-manifest"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "hex",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "specere-markers"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "serde_yaml",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "specere-telemetry"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "specere-units"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.1"
+version = "1.0.2"
 edition = "2021"
 rust-version = "1.78"
 authors = ["laiadlotape"]
@@ -50,12 +50,12 @@ ndarray = "0.16"
 rand = "0.8"
 fs2 = "0.4"
 
-specere-core = { path = "crates/specere-core", version = "1.0.1" }
-specere-units = { path = "crates/specere-units", version = "1.0.1" }
-specere-manifest = { path = "crates/specere-manifest", version = "1.0.1" }
-specere-markers = { path = "crates/specere-markers", version = "1.0.1" }
-specere-telemetry = { path = "crates/specere-telemetry", version = "1.0.1" }
-specere-filter = { path = "crates/specere-filter", version = "1.0.1" }
+specere-core = { path = "crates/specere-core", version = "1.0.2" }
+specere-units = { path = "crates/specere-units", version = "1.0.2" }
+specere-manifest = { path = "crates/specere-manifest", version = "1.0.2" }
+specere-markers = { path = "crates/specere-markers", version = "1.0.2" }
+specere-telemetry = { path = "crates/specere-telemetry", version = "1.0.2" }
+specere-filter = { path = "crates/specere-filter", version = "1.0.2" }
 
 [profile.release]
 lto = "thin"


### PR DESCRIPTION
Closes Phase 4 FR-P4-002 parity gap across all three filter paths.

## What's in v1.0.2

- **Issue #42 closed** (PR #59) — FactorGraphBP + RBPF Gate-A parity tests added. All FR-P4-002 acceptance criteria met: PerSpecHMM bit-identical, FactorGraphBP bit-identical, RBPF tail-MAP within 2 pp.
- **Self-dogfood test guide** (PR #58) — 38-scenario human-walkable suite in `docs/test-plans/`. Spot-checked clean against this candidate.

## Test plan

- [x] 178 workspace tests green.
- [ ] CI cross-platform.
- [ ] Tag push → 16 artifacts.