### PR TITLE
release: v1.0.3 — fix #61 + agentic test plan + status refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to SpecERE will be documented here. The format follows [Keep
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-04-19
+
+Dogfood finding from the self-dogfood guide's T-31 scenario → real bug caught + fixed. Plus a new test plan for interactive agent integration and project-wide status refresh.
+
+### Fixed
+- **`specere lint ears` feature.json parser hardened** (closes #61). Replaced the hand-rolled string search with proper `serde_json` deserialisation. The parser now accepts both the speckit convention (`feature_directory`) and a shorter `feature_dir` alias via `#[serde(alias)]`. Pre-fix, the `feature_dir` key errored with `could not parse feature_directory` — surfaced during the self-dogfood guide's T-31 execution. Same treatment applied to `specere-units::orphan::parse_feature_directory` for consistency. 2 new regression tests: `lint_ears_accepts_feature_dir_alias`, `lint_ears_rejects_malformed_feature_json`. Error messages now surface the full `serde_json` chain with line/column for malformed input.
+
+### Added
+- **`docs/test-plans/agentic-integration-plan.md`** — new human-walkable plan exercising specere transparently under a live Claude Code session. Covers hooks firing on all 7 `/speckit-*` verbs, span attrs contract, filter feedback loop, calibrate-then-refine cycle. 14-scenario checklist + 4 appendices (hook-wiring reference, debugging missing hooks, mid-test cleanup, known gaps).
+- **`docs/test-plans/self-dogfood-guide.md` — T-31 observation recorded** with a pointer to issue #61, plus a new "Observed run log" table tracking which versions pass which scenarios.
+
+### Changed
+- **`README.md` phase-status table refreshed** to reflect v1.0.3 shipped. All seven phases now marked ✅; the "not on crates.io" line points at the GitHub Release installer instead.
+- **`docs/upcoming.md` priority queue trimmed** to post-v1.0 polish items only: MarkerEntry backwards-compat, Phase 5 motion-matrix-fit tail, CLI RBPF routing, long spec-ID table alignment. Master-plan phase queue closed — v1.x is bug-fix + follow-ups.
+
 ## [1.0.2] - 2026-04-19
 
 Closes Phase 4 parity gap. FR-P4-002 now fully satisfied across all three filter paths.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "specere"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "specere-core"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "serde",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "specere-filter"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "approx",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "specere-manifest"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "hex",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "specere-markers"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "serde_yaml",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "specere-telemetry"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "specere-units"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 rust-version = "1.78"
 authors = ["laiadlotape"]
@@ -50,12 +50,12 @@ ndarray = "0.16"
 rand = "0.8"
 fs2 = "0.4"
 
-specere-core = { path = "crates/specere-core", version = "1.0.2" }
-specere-units = { path = "crates/specere-units", version = "1.0.2" }
-specere-manifest = { path = "crates/specere-manifest", version = "1.0.2" }
-specere-markers = { path = "crates/specere-markers", version = "1.0.2" }
-specere-telemetry = { path = "crates/specere-telemetry", version = "1.0.2" }
-specere-filter = { path = "crates/specere-filter", version = "1.0.2" }
+specere-core = { path = "crates/specere-core", version = "1.0.3" }
+specere-units = { path = "crates/specere-units", version = "1.0.3" }
+specere-manifest = { path = "crates/specere-manifest", version = "1.0.3" }
+specere-markers = { path = "crates/specere-markers", version = "1.0.3" }
+specere-telemetry = { path = "crates/specere-telemetry", version = "1.0.3" }
+specere-filter = { path = "crates/specere-filter", version = "1.0.3" }
 
 [profile.release]
 lto = "thin"

--- a/README.md
+++ b/README.md
@@ -32,20 +32,28 @@ This uninstall-first design is SpecERE's core UX differentiator versus SpecKit, 
 
 ## Status
 
-**Pre-0.1.0 release** — `0.2.0-dev` on `main`. Phase 1 merged; v0.2.0 tag not yet cut (release infrastructure is the next spec). Not yet on crates.io.
+**v1.0.3 on `main`** — all seven master-plan phases shipped. `specere calibrate from-git` surfaces real architectural coupling on live repos. Full Gate-A parity with the ReSearch Python prototype (bit-identical for PerSpecHMM + FactorGraphBP; tail-MAP-within-2-pp for RBPF).
+
+Not on crates.io yet; install from the [GitHub Release](https://github.com/laiadlotape/specere/releases/latest) shell / powershell installer.
 
 | Phase | What ships | Status |
 |---|---|---|
-| Phase 0 — doc rectification       | README / CONTRIBUTING / CHANGELOG aligned to pivot           | ✅ Shipped (2026-04-18) |
-| Phase 1 — bugfix release `v0.2.0` | Drop `--no-git`, SHA-diff gate, first `after_implement` hook, marker-fenced `.gitignore`, bit-identical remove, parse-safety | ✅ Merged (PR #2, 2026-04-18) — 9 FRs, 37/37 tests green on Linux/macOS/Windows; v0.2.0 tag pending release-infra |
-| Phase 2 — native units            | All 5 MVP units implemented end-to-end                       | ✅ Shipped (2026-04-18) — PRs #19–#23; all 5 units real; `specere init` composes the full scaffold; 65/65 tests cross-platform |
-| Phase 3 — observe pipeline        | Embedded OTLP receiver + `specere-observe` workflow          | ✅ Shipped (2026-04-18) — PRs #32–#36 + #38; OTLP/HTTP + gRPC receivers + SQLite event store + 13 workflow-span hooks; FR-P3-001 through FR-P3-006 all closed. |
-| Phase 4 — filter engine           | Rust port of the ReSearch prototype's three Bayesian filters | ✅ Main track shipped (2026-04-18) — PRs #45–#48; `specere-filter` crate with PerSpecHMM + FactorGraphBP + RBPF + `specere filter run/status` CLI; 150/150 tests. FR-P4-001/003/004/006 closed; FR-P4-002 (Python parity) + FR-P4-005 (throughput) queued as follow-ups. |
-| Phase 5 — motion-model calibration| `specere calibrate from-git`                                 | ⏳ Next (see [`docs/upcoming.md`](docs/upcoming.md)) |
-| Phase 6 — cross-session persistence | Posterior survives across sessions                         | ⏳ Planned |
-| Phase 7 — v1.0.0 release          | Final tear-down-and-rebuild dogfood on ReSearch              | ⏳ Planned |
+| Phase 0 — doc rectification | README / CONTRIBUTING / CHANGELOG aligned to pivot | ✅ Shipped (2026-04-18) |
+| Phase 1 — bugfix release | Drop `--no-git`, SHA-diff gate, first `after_implement` hook, marker-fenced `.gitignore`, bit-identical remove, parse-safety | ✅ v0.2.0 (2026-04-18) — 9 FRs, 37/37 tests |
+| Phase 2 — native units | All 5 MVP units implemented end-to-end | ✅ Shipped (2026-04-18) — 5 units real; `specere init` composes the full scaffold; 65/65 tests |
+| Phase 3 — observe pipeline | Embedded OTLP receiver + `specere-observe` workflow | ✅ v0.4.0 (2026-04-18) — OTLP HTTP + gRPC + SQLite event store + 13 workflow-span hooks; FR-P3-001 through FR-P3-006 closed |
+| Phase 4 — filter engine | Rust port of the ReSearch prototype's three Bayesian filters | ✅ v0.4.0 / v0.4.0 follow-ups — PerSpecHMM + FactorGraphBP + RBPF + `specere filter run/status` CLI; FR-P4-001 through FR-P4-006 closed; Python-prototype parity bit-identical on Gate-A for PerSpecHMM + BP |
+| Phase 5 — motion-model calibration | `specere calibrate from-git` | ✅ v0.5.0 (partial) — coupling-edge suggester from git log co-modification; full motion-matrix fit deferred (needs test-history source) |
+| Phase 6 — cross-session persistence | Posterior survives across sessions | ✅ v1.0.0 — posterior bit-identical across process restarts; FR-P6 regression caught + fixed |
+| Phase 7 — v1.0.0 release | Final tear-down-and-rebuild dogfood on ReSearch | ✅ v1.0.0 (2026-04-18); v1.0.1 calibrate path-prefix fix; v1.0.2 RBPF/BP parity closes #42; v1.0.3 ears-lint parser hardening closes #61 |
 
-See [`CHANGELOG.md`](./CHANGELOG.md) for release notes, [`docs/specere_v1.md`](docs/specere_v1.md) for the 36-FR / 7-SC master plan, and [`docs/upcoming.md`](docs/upcoming.md) for the queued-next specs.
+**Release:** current stable is **v1.0.3**. See [CHANGELOG.md](./CHANGELOG.md) for the full history.
+
+**Test plans for contributors:**
+- [`docs/test-plans/self-dogfood-guide.md`](docs/test-plans/self-dogfood-guide.md) — 38-scenario CLI-driven smoke suite, ~25 min.
+- [`docs/test-plans/agentic-integration-plan.md`](docs/test-plans/agentic-integration-plan.md) — interactive Claude Code session validating hooks + filter end-to-end.
+
+See [`docs/specere_v1.md`](docs/specere_v1.md) for the 36-FR / 7-SC master plan.
 
 ## Design documents
 

--- a/crates/specere-units/src/ears_lint.rs
+++ b/crates/specere-units/src/ears_lint.rs
@@ -59,9 +59,9 @@ pub fn run(repo: &Path) -> anyhow::Result<LintOutcome> {
     }
 
     let feat_raw = std::fs::read_to_string(&feature_json)?;
-    let feature_dir_rel = parse_feature_directory(&feat_raw).ok_or_else(|| {
+    let feature_dir_rel = parse_feature_directory(&feat_raw).map_err(|e| {
         anyhow::anyhow!(
-            "could not parse feature_directory from {}",
+            "parsing {}: {e} — expected a JSON object with key `feature_directory` (or alias `feature_dir`)",
             feature_json.display()
         )
     })?;
@@ -186,16 +186,23 @@ fn extract_fr_bullets(spec: &str) -> Vec<String> {
     bullets
 }
 
-fn parse_feature_directory(raw: &str) -> Option<String> {
-    let key = "\"feature_directory\"";
-    let start = raw.find(key)? + key.len();
-    let rest = &raw[start..];
-    let colon = rest.find(':')?;
-    let after_colon = &rest[colon + 1..];
-    let quote1 = after_colon.find('"')?;
-    let after_q1 = &after_colon[quote1 + 1..];
-    let quote2 = after_q1.find('"')?;
-    Some(after_q1[..quote2].to_string())
+/// Parse `.specify/feature.json`. Accepts `feature_directory` (the speckit
+/// convention) or the shorter `feature_dir` alias (what hook authors
+/// commonly reach for). Issue #61 — previously a hand-rolled string search
+/// that was both fragile (broke on any JSON whitespace reshuffle) and
+/// rigid (only the exact key name would match).
+fn parse_feature_directory(raw: &str) -> anyhow::Result<String> {
+    #[derive(serde::Deserialize)]
+    struct FeatureJson {
+        #[serde(alias = "feature_dir")]
+        feature_directory: String,
+    }
+    let parsed: FeatureJson =
+        serde_json::from_str(raw).map_err(|e| anyhow::anyhow!("JSON parse error: {e}"))?;
+    if parsed.feature_directory.trim().is_empty() {
+        anyhow::bail!("`feature_directory` is empty");
+    }
+    Ok(parsed.feature_directory)
 }
 
 fn truncate(s: &str, max: usize) -> String {

--- a/crates/specere-units/src/orphan.rs
+++ b/crates/specere-units/src/orphan.rs
@@ -89,16 +89,17 @@ pub fn clean(repo: &Path, state: &OrphanState) -> std::io::Result<()> {
 }
 
 fn parse_feature_directory(raw: &str) -> Option<String> {
-    // Dependency-free parse: look for `"feature_directory":"<value>"`.
-    let key = "\"feature_directory\"";
-    let start = raw.find(key)? + key.len();
-    let rest = &raw[start..];
-    let colon = rest.find(':')?;
-    let after_colon = &rest[colon + 1..];
-    let quote1 = after_colon.find('"')?;
-    let after_q1 = &after_colon[quote1 + 1..];
-    let quote2 = after_q1.find('"')?;
-    Some(after_q1[..quote2].to_string())
+    // Proper JSON parse via serde_json. Accepts `feature_directory` (speckit
+    // convention) or `feature_dir` (shorter alias). Issue #61.
+    #[derive(serde::Deserialize)]
+    struct FeatureJson {
+        #[serde(alias = "feature_dir")]
+        feature_directory: String,
+    }
+    serde_json::from_str::<FeatureJson>(raw)
+        .ok()
+        .map(|p| p.feature_directory)
+        .filter(|s| !s.trim().is_empty())
 }
 
 fn spec_md_is_template(path: &Path) -> bool {

--- a/crates/specere/tests/issue_025_ears_lint_cli.rs
+++ b/crates/specere/tests/issue_025_ears_lint_cli.rs
@@ -41,6 +41,63 @@ fn setup_foo_feature(repo: &TempRepo) {
 }
 
 #[test]
+fn lint_ears_accepts_feature_dir_alias() {
+    // Issue #61 regression — the parser used to only accept the full
+    // `feature_directory` key name. The self-dogfood guide's T-31 scenario
+    // documented `feature_dir` which errored. Now both aliases work.
+    let repo = TempRepo::new();
+    std::fs::create_dir_all(repo.abs(".specere/lint")).unwrap();
+    repo.write(
+        ".specere/lint/ears.toml",
+        include_str!("../../specere-units/src/ears_linter/rules.toml"),
+    );
+    std::fs::create_dir_all(repo.abs(".specify")).unwrap();
+    repo.write(
+        ".specify/feature.json",
+        r#"{"feature_dir":"specs/999-alias-test"}"#,
+    );
+    std::fs::create_dir_all(repo.abs("specs/999-alias-test")).unwrap();
+    repo.write("specs/999-alias-test/spec.md", FOO_SPEC);
+
+    let out = repo.run_specere(&["lint", "ears"]).output().expect("spawn");
+    assert!(
+        out.status.success(),
+        "lint ears should exit 0 on feature_dir alias.\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Sanity: findings still produced (same spec content as the main test).
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("FR-002") || stdout.contains("findings"),
+        "expected ears findings in stdout; got: {stdout}"
+    );
+}
+
+#[test]
+fn lint_ears_rejects_malformed_feature_json() {
+    // Issue #61 — the parser now uses serde_json so malformed JSON gets a
+    // clear parse-error chain rather than a silent "could not parse" string.
+    let repo = TempRepo::new();
+    std::fs::create_dir_all(repo.abs(".specere/lint")).unwrap();
+    repo.write(
+        ".specere/lint/ears.toml",
+        include_str!("../../specere-units/src/ears_linter/rules.toml"),
+    );
+    std::fs::create_dir_all(repo.abs(".specify")).unwrap();
+    repo.write(".specify/feature.json", "not valid json {{");
+    let out = repo.run_specere(&["lint", "ears"]).output().expect("spawn");
+    assert!(
+        !out.status.success(),
+        "lint ears should error on malformed JSON"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("feature_directory") && stderr.contains("feature_dir"),
+        "error should name both accepted keys for discoverability:\n{stderr}"
+    );
+}
+
+#[test]
 fn lint_ears_catches_three_bad_bullets() {
     let repo = TempRepo::new();
     setup_foo_feature(&repo);

--- a/docs/test-plans/agentic-integration-plan.md
+++ b/docs/test-plans/agentic-integration-plan.md
@@ -1,0 +1,367 @@
+# SpecERE agentic-integration test plan
+
+A human-walkable plan that exercises `specere` end-to-end under a **real Claude Code session**. Unlike `self-dogfood-guide.md` (which drives the CLI directly), this plan validates that specere runs transparently when an agent is actually doing work — that hooks fire on `/speckit-*` verbs, spans land in the event store, and the filter reflects the agent's actions in the posterior.
+
+**Target binary under test.** `specere` ≥ v1.0.3.
+
+**Duration.** ~20 minutes for the passive pass (session runs on its own, you just watch), ~40 minutes if you drive an actual feature through the full `/speckit-*` cycle.
+
+**Who this is for.** Maintainers who want to catch broken hooks before release. Contributors validating that their new skill / hook wires up correctly. Anyone debugging why a `/speckit-*` verb didn't emit a span.
+
+---
+
+## Prerequisites
+
+- Everything from `self-dogfood-guide.md` Prerequisites (git, cargo, uvx, python3, jq).
+- **Claude Code CLI** installed locally. Verify with `claude --version`.
+- `specere` ≥ v1.0.3 on `PATH` or via `$BIN`.
+- A writable scratch directory.
+
+---
+
+## Setup — sandbox + install
+
+```sh
+export SANDBOX=$HOME/Projects/tmp/specere-agentic-$(date +%s)
+git clone https://github.com/laiadlotape/specere "$SANDBOX"
+cd "$SANDBOX"
+
+# Strip harness state left by the project's own self-install.
+rm -rf .specere .specify
+rm -rf .claude/agents/specere-reviewer.md .claude/skills/specere-* .claude/skills/speckit-*
+git checkout -- CLAUDE.md .gitignore 2>/dev/null
+
+$BIN init
+$BIN verify           # should print: No drift.
+```
+
+Verify the harness is wired correctly:
+
+```sh
+cat .specify/extensions.yml          # should contain 14 hooks (before_<verb> × 7, after_<verb> × 6, after_implement bespoke)
+ls .claude/skills/specere-*          # should list: specere-adopt, specere-lint-ears, specere-observe-implement, specere-observe-step, specere-review-check, specere-review-drain
+ls .claude/agents/                   # should include specere-reviewer.md
+grep -c "specere:begin" CLAUDE.md    # should print: 1 (the rules block fence)
+```
+
+Populate sensor-map so the filter has something to reason about:
+
+```sh
+cat > .specere/sensor-map.toml <<'EOF'
+schema_version = 1
+
+[specs]
+"core"      = { support = ["crates/specere-core/"] }
+"units"     = { support = ["crates/specere-units/"] }
+"telemetry" = { support = ["crates/specere-telemetry/"] }
+"filter"    = { support = ["crates/specere-filter/"] }
+"cli"       = { support = ["crates/specere/src/"] }
+
+[channels]
+EOF
+```
+
+Cleanse the event store so the agent run starts from a known-empty state:
+
+```sh
+rm -f .specere/events.jsonl .specere/events.sqlite
+```
+
+---
+
+## Part A — Passive observation pass (workflow runner)
+
+In this pass you don't interact with Claude — you invoke the `specere-observe` workflow runner, which drives the full `/speckit-*` cycle end-to-end without human input. Every verb should emit a `before_<verb>` + `after_<verb>` span, plus the bespoke `after_implement` hook.
+
+### A-01 — launch the passive workflow
+
+In one terminal (with `$BIN` on PATH):
+
+```sh
+cd "$SANDBOX"
+specify workflow run specere-observe \
+  --input '{"feature_title": "agentic-smoke", "feature_branch": "999-agentic-smoke"}'
+```
+
+**Expected.** `specify workflow run` spawns a headless Claude session, walks `specify → clarify → plan → tasks → implement`, prints progress for each step, exits 0.
+
+(If you don't have SpecKit's `specify` CLI available — e.g. `uvx` isn't installed — skip to Part B and drive verbs interactively.)
+
+### A-02 — events landed for every verb
+
+```sh
+$BIN observe query --format table | head -30
+```
+
+**Expected.** At least 13 events (or more — the exact count depends on how many verbs the workflow ran). Each row shows `source = <verb>`, `signal = traces`. Verbs you should see at minimum: `specify`, `clarify`, `plan`, `tasks`, `implement`.
+
+### A-03 — attr contract is honoured
+
+```sh
+$BIN observe query --format json | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+by_source = {}
+for e in d:
+    by_source.setdefault(e['source'], []).append(e)
+for source, events in sorted(by_source.items()):
+    sample = events[0]
+    print(f'{source:12}  {len(events):3} event(s)  attrs: {sorted(sample[\"attrs\"].keys())}')
+"
+```
+
+**Expected.** Each unique `source` has one row. Every sample should show at least `gen_ai.system = claude-code`, `specere.workflow_step = <verb>`, `phase = before|after` in its attrs. Missing attrs = broken skill wiring.
+
+### A-04 — feature_dir attribute is populated
+
+```sh
+$BIN observe query --format json | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+with_fd = [e for e in d if e.get('feature_dir')]
+print(f'events with feature_dir: {len(with_fd)}/{len(d)}')
+if with_fd:
+    print('sample:', with_fd[0]['feature_dir'])
+"
+```
+
+**Expected.** Every event after `/speckit-specify` has set `feature_dir` = `specs/999-agentic-smoke` (or whatever branch-name mapping speckit assigned). Events from before the feature was created may have empty feature_dir.
+
+### A-05 — advance the filter
+
+```sh
+$BIN filter run
+$BIN filter status
+```
+
+**Expected.** The `filter run` output reports a sensible `processed`/`skipped` ratio. Most workflow spans will be `skipped` because they carry `event_kind=workflow_step` (or no `event_kind`), not `test_outcome` or `files_touched`. This is **correct behaviour** — the filter only advances on actual test results, not on workflow milestones.
+
+The posterior may therefore be empty or show only specs touched by write events. If you want to see the filter advance, proceed to Part C.
+
+---
+
+## Part B — Interactive session
+
+In this pass you open Claude Code interactively and run verbs by hand. Useful for debugging a specific hook.
+
+### B-01 — open Claude Code in the sandbox
+
+```sh
+cd "$SANDBOX"
+claude
+```
+
+Inside the Claude session, run:
+
+```
+/specere-reviewer  Check the repo is ready to specify a new feature
+```
+
+**Expected.** The `specere-reviewer` agent responds (from `.claude/agents/specere-reviewer.md`). This proves the agent surface is wired.
+
+### B-02 — run `/speckit-specify` interactively
+
+Inside the Claude session:
+
+```
+/speckit-specify  widget — a toy feature that returns HTTP 200
+```
+
+**Expected.** Claude produces `specs/NNN-widget/spec.md`. In a second terminal, check the event store:
+
+```sh
+$BIN observe query --source specify --format json | python3 -m json.tool | head -30
+```
+
+There should be at least one event with `source=specify`, `attrs.phase` in {before, after}, and a timestamp close to when the verb ran.
+
+### B-03 — run the rest of the cycle
+
+One at a time in Claude:
+
+```
+/speckit-clarify
+/speckit-plan
+/speckit-tasks
+/speckit-implement
+```
+
+**Expected.** After each verb:
+
+```sh
+$BIN observe query --source <verb> | head
+```
+
+shows at least one new event. The `/speckit-implement` verb also triggers the bespoke `specere-observe-implement` skill (separate from the generic `specere-observe-step`), which fires on the `after_implement` hook.
+
+### B-04 — drive test outcomes through the filter
+
+To see the filter move, record synthetic test outcomes matching the specs you edited during `/speckit-implement`:
+
+```sh
+# E.g. if the feature touched crates/specere-filter/...
+$BIN observe record --source cargo-test \
+  --attr event_kind=test_outcome --attr spec_id=filter --attr outcome=pass
+$BIN observe record --source cargo-test \
+  --attr event_kind=test_outcome --attr spec_id=filter --attr outcome=pass
+
+$BIN filter run
+$BIN filter status
+```
+
+**Expected.** `filter` spec lean toward SAT (`p_sat > 0.7` after 2 passes).
+
+### B-05 — confirm the `specere-observe-step` skill fires with the right attrs
+
+A hook should emit a span with:
+
+- `source` = the verb (e.g., `implement`)
+- `attrs.event_kind = workflow_step`
+- `attrs.phase` in {before, after}
+- `attrs.gen_ai.system = claude-code`
+- `attrs.specere.workflow_step = <verb>`
+
+Spot-check:
+
+```sh
+$BIN observe query --source implement --format json | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+if not d:
+    print('FAIL: no events with source=implement — implement hook did not fire')
+    sys.exit(1)
+for e in d:
+    attrs = e.get('attrs', {})
+    missing = [k for k in ['event_kind','phase','gen_ai.system','specere.workflow_step'] if k not in attrs]
+    if missing:
+        print(f'FAIL: event at {e[\"ts\"]} missing attrs: {missing}')
+    else:
+        print(f'OK: {e[\"ts\"]}  phase={attrs[\"phase\"]}')
+"
+```
+
+**Expected.** Every event prints `OK`. Any `FAIL` indicates a broken hook / skill wiring.
+
+---
+
+## Part C — Full feedback loop (calibrate → run → refine)
+
+The belief surface is most useful when calibrated against the repo's own history. This part closes the loop.
+
+### C-01 — calibrate from git
+
+```sh
+$BIN calibrate from-git --max-commits 200 > /tmp/coupling-proposal.toml
+cat /tmp/coupling-proposal.toml
+```
+
+**Expected.** A `[coupling]` TOML snippet with edges proposed from the real commit history.
+
+### C-02 — paste the coupling into sensor-map + re-run filter
+
+```sh
+# Append the `[coupling]` section to sensor-map (manually or with awk/sed).
+awk '/^\[coupling\]/,/^$/' /tmp/coupling-proposal.toml >> .specere/sensor-map.toml
+cat .specere/sensor-map.toml
+$BIN filter run
+$BIN filter status
+```
+
+**Expected.** With coupling wired, the filter dispatches to `FactorGraphBP` instead of `PerSpecHMM`. Fail events on one spec should now lift adjacent specs' VIO mass via BP messages.
+
+### C-03 — observe a session then re-calibrate
+
+After a few real `/speckit-*` cycles worth of commits, re-run calibrate:
+
+```sh
+$BIN calibrate from-git --max-commits 500
+```
+
+New coupling proposals may appear if the session produced co-modifying commits. This is the loop the SpecERE vision promises: agent activity → events → belief → calibration → better coupling model.
+
+---
+
+## Part D — Cleanup
+
+```sh
+cd "$SANDBOX"
+for u in ears-linter otel-collector claude-code-deploy filter-state speckit; do
+  $BIN remove "$u" --force
+done
+cd /
+rm -rf "$SANDBOX"
+```
+
+---
+
+## Checklist
+
+| # | Part | Scenario | Pass |
+|---|---|---|---|
+| A-01 | A | `specify workflow run specere-observe` runs end-to-end | ☐ |
+| A-02 | A | events landed for every workflow verb | ☐ |
+| A-03 | A | attrs contract honoured (gen_ai, workflow_step, phase) | ☐ |
+| A-04 | A | feature_dir attribute populated after `/speckit-specify` | ☐ |
+| A-05 | A | filter run/status tolerates workflow-only events | ☐ |
+| B-01 | B | `/specere-reviewer` agent responds inside Claude Code | ☐ |
+| B-02 | B | `/speckit-specify` emits a span | ☐ |
+| B-03 | B | clarify / plan / tasks / implement all emit spans | ☐ |
+| B-04 | B | filter advances on synthetic test outcomes | ☐ |
+| B-05 | B | specere-observe-step skill emits the right attrs | ☐ |
+| C-01 | C | `calibrate from-git` proposes coupling | ☐ |
+| C-02 | C | coupling pasted + filter dispatches to BP | ☐ |
+| C-03 | C | post-session re-calibrate shows new co-modification | ☐ |
+| D   | D | full uninstall + sandbox teardown | ☐ |
+
+---
+
+## Appendix A — Hook wiring reference
+
+| Hook name | Registered in `extensions.yml` | Calls |
+|---|---|---|
+| `before_specify`, `after_specify` | auto | `specere-observe-step` skill |
+| `before_clarify`, `after_clarify` | auto | `specere-observe-step` + `ears-linter` (before only) |
+| `before_plan`, `after_plan` | auto | `specere-observe-step` |
+| `before_tasks`, `after_tasks` | auto | `specere-observe-step` |
+| `before_analyze`, `after_analyze` | auto | `specere-observe-step` |
+| `before_checklist`, `after_checklist` | auto | `specere-observe-step` |
+| `before_implement` | auto | `specere-observe-step` |
+| `after_implement` | auto | **bespoke** `specere-observe-implement` (preserves FR-P1-005) |
+
+Total: 14 hooks across 7 verbs. If any verb produces only one event (either before or after but not both), check `.specify/extensions.yml` for that verb's hook stanza.
+
+## Appendix B — Debugging a missing hook
+
+1. **Skill not found.** Check `.claude/skills/specere-observe-step/SKILL.md` exists.
+2. **Hook registered but doesn't fire.** Check `.specify/extensions.yml` has the hook. Run `specere verify` — if it reports `drift` on `extensions.yml`, fix with `specere add claude-code-deploy --adopt-edits`.
+3. **Fires but no event lands.** Check `specere observe record` is on `PATH` (the skill shells out to the binary). Try manually:
+   ```sh
+   $BIN observe record --source test --attr event_kind=workflow_step --attr specere.workflow_step=test --attr phase=before --attr gen_ai.system=claude-code
+   $BIN observe query --source test | tail
+   ```
+4. **Event lands but missing attrs.** Inspect the skill file at `.claude/skills/specere-observe-step/SKILL.md`; its prompt tells Claude which attrs to emit.
+
+## Appendix C — Tearing down mid-test
+
+If the session hangs or produces unexpected state:
+
+```sh
+# Kill any rogue specere serve processes
+pkill -f "specere serve" || true
+# Reset the event store
+rm -f .specere/events.jsonl .specere/events.sqlite .specere/posterior.toml
+# Reset harness state
+cd "$SANDBOX"
+for u in ears-linter otel-collector claude-code-deploy filter-state speckit; do
+  $BIN remove "$u" --force 2>/dev/null
+done
+rm -rf .specere .specify .claude/skills/specere-* .claude/skills/speckit-* .claude/agents/specere-reviewer.md
+git checkout -- CLAUDE.md .gitignore 2>/dev/null
+$BIN init
+```
+
+## Appendix D — Known gaps
+
+- **Workflow spans don't advance the filter on their own.** By design — `event_kind=workflow_step` is an advisory signal (agent-is-doing-thing), not a test outcome. Only `test_outcome` and `files_touched` events feed the filter. This means Part A's filter output will look empty; Part B + C is where the filter actually moves.
+- **No auto-calibration trigger yet.** Users must run `specere calibrate from-git` manually. A future phase may add a post-implement hook that re-calibrates automatically.
+- **`specere serve` ingress via Claude Code hooks is not wired.** Hooks currently shell out to `specere observe record` (CLI), not post to `localhost:4318`. Switching the skills to HTTP-POST would unlock richer attrs at the cost of requiring a running serve. This is an intentional v1 simplification.

--- a/docs/test-plans/self-dogfood-guide.md
+++ b/docs/test-plans/self-dogfood-guide.md
@@ -2,7 +2,7 @@
 
 A human-walkable end-to-end test plan that installs `specere` onto a fresh clone of its own source tree, exercises every verb and subcommand, and uninstalls cleanly. Designed as a one-sitting smoke suite before cutting a release.
 
-**Target binary under test:** `specere` ≥ v1.0.1 (earlier versions will fail T-01 because the backwards-compat fixes from that release are required when the target repo was previously touched by pre-v0.5.0 builds).
+**Target binary under test:** `specere` ≥ v1.0.3 (T-31 requires the [issue #61](https://github.com/laiadlotape/specere/issues/61) fix to accept the `feature_dir` alias; earlier versions will fail T-31 with `could not parse feature_directory`).
 
 **Duration.** ~25 minutes the first time, ~10 minutes after.
 
@@ -22,13 +22,13 @@ If you're testing a local build, have the binary path ready:
 
 ```sh
 export BIN=$(realpath /path/to/specere/target/release/specere)
-$BIN --version                      # should print: specere 1.0.1 (or newer)
+$BIN --version                      # should print: specere 1.0.3 (or newer)
 ```
 
 If you're testing the installer-bundled binary, add it to `PATH` first:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/laiadlotape/specere/releases/download/v1.0.1/specere-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/laiadlotape/specere/releases/download/v1.0.3/specere-installer.sh | sh
 export BIN=$HOME/.cargo/bin/specere   # or wherever the installer placed it
 ```
 
@@ -520,7 +520,7 @@ cat > specs/999-smoke/spec.md <<'EOF'
 - FR-003: When X happens, THE system MUST do Y.
 EOF
 cat > .specify/feature.json <<'EOF'
-{"feature_dir": "specs/999-smoke"}
+{"feature_directory": "specs/999-smoke"}
 EOF
 $BIN lint ears
 ```
@@ -528,6 +528,8 @@ $BIN lint ears
 **Expected:** advisory findings for FR-002 (missing `THE SYSTEM`/`MUST`/`SHALL`), no fatal exit — `lint ears` always exits 0 per the advisory-only contract.
 
 Clean up: `rm -rf specs/999-smoke .specify/feature.json`.
+
+**Known issue — fixed in v1.0.3 ([#61](https://github.com/laiadlotape/specere/issues/61)).** On v1.0.2 and earlier this scenario erred with `could not parse feature_directory from .../feature.json` if the JSON used the shorter `feature_dir` key. v1.0.3's `parse_feature_directory` is serde_json-based and accepts either `feature_directory` (shown above) or `feature_dir` via `#[serde(alias)]`. If you're on v1.0.2 or earlier, use the full `feature_directory` key name.
 
 ---
 
@@ -668,7 +670,14 @@ rm -rf "$SANDBOX"
 - **`filter status` may print rows in a different order than the on-disk entries.** Entries in `posterior.toml` are always sorted by `spec_id` (for FR-P4-004 byte-stability). `filter status` then re-sorts them per `--sort`. If you diff posterior.toml bytes you'll see spec_id order; if you diff `filter status` output you'll see entropy-desc order.
 - **`filter-state::remove` preserves runtime-edited files** (posterior, sensor-map, events.sqlite, events.jsonl). This is intentional — the user may want to keep their history. Use `rm -rf .specere` if you genuinely want a clean slate.
 - **`specere remove claude-code-deploy --force`** leaves `.claude/skills/speckit-git-*` if they weren't installed by the current specere version. Older installs wrote fewer skills; `remove` only cleans what that install tracked in its manifest. Safe to leave or delete by hand.
-- **`specere init` on the upstream specere repo** will fail with `missing field unit_id` if the repo's committed `.specere/manifest.toml` predates the MarkerEntry schema. The Setup step above removes this manifest before init — if you're testing a real user-facing upgrade flow, the proper regression fix is to make `unit_id` optional on MarkerEntry (tracked as a follow-up; not blocking v1.0.1).
+- **`specere init` on the upstream specere repo** will fail with `missing field unit_id` if the repo's committed `.specere/manifest.toml` predates the MarkerEntry schema. The Setup step above removes this manifest before init — if you're testing a real user-facing upgrade flow, the proper regression fix is to make `unit_id` optional on MarkerEntry (tracked as a follow-up; not blocking current releases).
+
+## Observed run log
+
+| Version | Date | All 38 pass? | Notes |
+|---|---|---|---|
+| v1.0.2 | 2026-04-19 | 37/38 | T-31 surfaced issue #61 (feature.json parser rigid on key name). Fixed in v1.0.3. |
+| v1.0.3 | 2026-04-19 | anticipate 38/38 | #61 fixed; T-31 guide updated to use `feature_directory` and note the new `feature_dir` alias. |
 
 ## Appendix B — Cleanup between test runs
 

--- a/docs/upcoming.md
+++ b/docs/upcoming.md
@@ -6,21 +6,31 @@
 
 ## Priority queue (highest first)
 
-### 1. `phase-4-follow-ups` — FR-P4-002 Python parity + FR-P4-005 throughput
+**Nothing blocking a release.** All seven master-plan phases shipped through v1.0.3. The items below are polish-level follow-ups.
 
-- **Why it's next.** Phase 4 main track landed but deliberately deferred two FRs: FR-P4-002 (< 2 pp tail-MAP parity with `prototype/mini_specs/filter.py` on Gate-A) and FR-P4-005 (≥ 1000 events/s throughput smoke). Both need a one-time Gate-A fixture export from the Python prototype, plus a 10k-event `#[ignore]`-gated benchmark test.
-- **Deliverables.** Export script at `scripts/export_gate_a_posterior.py` writing a committed TOML fixture under `crates/specere-filter/tests/fixtures/gate_a/`. Parity test driver at `crates/specere-filter/tests/gate_a_parity.rs` that loads the fixture and asserts `abs(rust_belief - py_belief) < 0.02` row-wise. Throughput test at `crates/specere/tests/fr_p4_005_throughput.rs` gated on `--ignored`.
-- **Phase mapping.** `docs/specere_v1.md §5.P4` FR-P4-002 + FR-P4-005.
-- **Workflow.** Single PR after filing an issue per `docs/contributing-via-issues.md`.
+### 1. MarkerEntry schema backwards-compat
 
-### 2. `phase-5-motion-calibration` — calibrate transition matrices from git history
+- **Why.** The specere repo's own committed `.specere/manifest.toml` uses an early pre-`unit_id` MarkerEntry schema. `specere status` / `verify` on a fresh clone of the upstream repo errors with `missing field unit_id`. The self-dogfood guide's Setup block works around this by deleting `.specere/` first — but a real user upgrading from a very early SpecERE install would also hit it.
+- **Fix.** `#[serde(default)]` on `MarkerEntry.unit_id`; infer from the containing `[[units]].unit_id` during deserialisation.
+- **Scope.** Small — ~20 LoC in `specere-core` + a regression test that loads the old-schema manifest cleanly.
 
-- **Why.** Phase 4 uses the prototype's verbatim `Motion` defaults; Phase 5 learns them per-spec from the repo's commit history. `specere calibrate from-git` walks git log, reconstructs (diff, test-delta) pairs, and fits `t_good`/`t_bad` per spec.
-- **Phase mapping.** `docs/specere_v1.md §5.P5`.
+### 2. Motion-matrix fit from `(diff, test-delta)` pairs (Phase 5 tail)
+
+- **Why.** v0.5.0 shipped the coupling-edge suggester half of Phase 5; the motion-matrix fit half was deferred because it needs a durable per-commit test-history source (CI run records, not just event JSONL).
+- **Blocker.** No CI-result ingestion yet. A new `specere calibrate from-ci <path-to-junit.xml>` subcommand would unlock this.
+
+### 3. RBPF CLI routing
+
+- **Why.** Library supports it; CLI picks PerSpecHMM or FactorGraphBP only. Users with cyclic coupling graphs get a "DAG required" error from the loader rather than auto-routing to RBPF.
+- **Fix.** Read a `[rbpf]` section from sensor-map.toml with cluster + particle config, branch `run_filter_run` accordingly.
+
+### 4. Long spec-ID table alignment
+
+- Cosmetic — table column width fixed at 11 chars; JSON output is the programmatic path. Noted in self-dogfood phase-4 manual-test report M-16.
 
 ## Beyond the immediate queue
 
-Phases 6–7 (cross-session persistence, v1.0.0 dogfood) remain as in the master plan.
+Nothing in the master plan is open. v1.x is bug-fix + follow-ups only; v2.0 would be a deliberate schema-breaking re-plan.
 
 ## Recently closed
 


### PR DESCRIPTION
## Closes #61 (feature.json parser)

Surfaced during the self-dogfood guide's T-31 scenario: \`specere lint ears\` errored on \`.specify/feature.json\` when it used the \`feature_dir\` key (as documented in the guide) instead of the speckit-convention \`feature_directory\`.

- Hand-rolled string-search parser replaced with \`serde_json\` + \`#[serde(alias = \"feature_dir\")]\`.
- Same treatment in \`specere-units::orphan::parse_feature_directory\` for consistency.
- Malformed JSON now surfaces the full \`serde_json\` chain with line/column.
- 2 new regression tests: alias acceptance + malformed-JSON error shape.

## New: \`docs/test-plans/agentic-integration-plan.md\`

14-scenario interactive walkthrough for testing specere under a live Claude Code session (workflow runner + interactive verbs + calibrate feedback loop). Complements the existing \`self-dogfood-guide.md\` (CLI-driven).

## Status refresh

- **README.md** — phase-status table updated; all 7 master-plan phases now ✅. Install instructions point at the GitHub Release installer instead of \"not on crates.io.\"
- **docs/upcoming.md** — master-plan queue closed. Remaining items: post-v1.0 polish (MarkerEntry backwards-compat, motion-matrix-fit tail, CLI RBPF routing, long spec-ID table alignment).
- **self-dogfood-guide.md** — T-31 corrected to use \`feature_directory\`, linked to #61 for the alias explanation. New \"Observed run log\" table records v1.0.2 = 37/38, v1.0.3 anticipates 38/38.

## Tests

180 workspace tests (178 + 2 new for #61). Clippy + fmt clean.

## Release mechanics

Workspace version 1.0.2 → 1.0.3. CHANGELOG \`[Unreleased]\` → \`[1.0.3] - 2026-04-19\`. Standard tag-cut flow on merge.