### PR TITLE
release: v1.0.4 — fix #63 / #64 / #65 from self-dogfood run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to SpecERE will be documented here. The format follows [Keep
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-04-19
+
+Three bugs caught during the self-dogfood guide's extended run on real repos. All three now have regression tests and default-rule updates.
+
+### Fixed
+- **`specere lint ears` no longer panics on multi-byte UTF-8 in FR lines** (closes #63). `truncate` in `ears_lint.rs` previously sliced a `&str` at a byte offset that could land inside a UTF-8 codepoint (`≥`, `→`, `€`, em-dashes, smart-quotes — all common in technical specs). The panic leaked through the advisory-only contract (exit 0) and silently dropped every would-be finding for the affected spec. `truncate` now snaps `max` back to the nearest char boundary. 4 new `truncate` unit tests + 1 end-to-end `lint_ears_tolerates_multibyte_utf8_in_fr_line` integration test exercising `≥ → ≠ ≤ —`.
+- **`specere remove speckit` sweeps orphan `.claude/skills/speckit-git-*`** (closes #64). The upstream `specify integration uninstall` hook doesn't always enumerate the `speckit-git-{commit,feature,initialize,remote,validate}` skill dirs it installed, and they aren't recorded in specere's manifest (speckit is a wrapper unit). Remove now best-effort deletes any `speckit-git-*` directory under `.claude/skills/`. Deliberately does NOT sweep other `speckit-*` skills (`speckit-plan`, `speckit-implement`, …) — those belong to `claude-code-deploy` and are tracked in its manifest. New integration tests in `crates/specere/tests/issue_064_speckit_orphan_skills.rs` verify both the sweep and the preservation of non-speckit-git skills.
+- **Default EARS rules accept canonical `SHALL` / `MAY` and domain-prefixed FR IDs** (closes #65). Pre-fix: `ears-fr-prefix` rejected `FR-AUTH-001` / `FR-EDITOR-018` (common convention); `ears-must-should` rejected `SHALL` and `MAY` (canonical EARS imperatives per Mavin et al.). Post-fix: `ears-fr-prefix` pattern is `^\s*-\s*\*\*FR(-P\d+)?(-[A-Z][A-Z0-9]+)?-\d{3,}\*\*:`; `ears-must-should` is `\b(MUST|SHALL|SHOULD|MAY)\b`. New regression `lint_ears_accepts_ears_canonical_shall_and_domain_prefixed_ids`.
+
+### Test count
+
+188 workspace tests (180 → +8: 4 truncate units, 1 UTF-8 integration, 2 speckit-orphan integrations, 1 EARS-canonical regression).
+
 ## [1.0.3] - 2026-04-19
 
 Dogfood finding from the self-dogfood guide's T-31 scenario → real bug caught + fixed. Plus a new test plan for interactive agent integration and project-wide status refresh.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "specere"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "specere-core"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "serde",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "specere-filter"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "approx",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "specere-manifest"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "hex",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "specere-markers"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "serde_yaml",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "specere-telemetry"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "specere-units"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 rust-version = "1.78"
 authors = ["laiadlotape"]
@@ -50,12 +50,12 @@ ndarray = "0.16"
 rand = "0.8"
 fs2 = "0.4"
 
-specere-core = { path = "crates/specere-core", version = "1.0.3" }
-specere-units = { path = "crates/specere-units", version = "1.0.3" }
-specere-manifest = { path = "crates/specere-manifest", version = "1.0.3" }
-specere-markers = { path = "crates/specere-markers", version = "1.0.3" }
-specere-telemetry = { path = "crates/specere-telemetry", version = "1.0.3" }
-specere-filter = { path = "crates/specere-filter", version = "1.0.3" }
+specere-core = { path = "crates/specere-core", version = "1.0.4" }
+specere-units = { path = "crates/specere-units", version = "1.0.4" }
+specere-manifest = { path = "crates/specere-manifest", version = "1.0.4" }
+specere-markers = { path = "crates/specere-markers", version = "1.0.4" }
+specere-telemetry = { path = "crates/specere-telemetry", version = "1.0.4" }
+specere-filter = { path = "crates/specere-filter", version = "1.0.4" }
 
 [profile.release]
 lto = "thin"

--- a/crates/specere-units/src/ears_lint.rs
+++ b/crates/specere-units/src/ears_lint.rs
@@ -205,10 +205,66 @@ fn parse_feature_directory(raw: &str) -> anyhow::Result<String> {
     Ok(parsed.feature_directory)
 }
 
+/// Truncate a string to at most `max` BYTES, snapping to the nearest char
+/// boundary at or below `max` so we never slice mid-codepoint. Appends `…`
+/// when truncation actually happened.
+///
+/// Issue #63: the previous `&s[..max]` slice panicked on multi-byte UTF-8
+/// (`≥`, `→`, `€`, smart-quotes, em-dashes) because `max` landed inside a
+/// codepoint. Common in technical specs.
 fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
-        s.to_string()
-    } else {
-        format!("{}…", &s[..max])
+        return s.to_string();
+    }
+    let mut boundary = max;
+    while boundary > 0 && !s.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    format!("{}…", &s[..boundary])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_under_max_is_noop() {
+        assert_eq!(truncate("short", 10), "short");
+    }
+
+    #[test]
+    fn truncate_at_char_boundary_snaps_ascii() {
+        // "hello world" → max=5 gives "hello…"
+        let out = truncate("hello world", 5);
+        assert_eq!(out, "hello…");
+    }
+
+    #[test]
+    fn truncate_snaps_to_char_boundary_on_multibyte() {
+        // Issue #63 repro — `≥` is 3 bytes (e2 89 a5). Any max landing inside
+        // those 3 bytes must snap back to the byte before the char.
+        let s = "rate ≥ 60 Hz sustained";
+        // Try several `max` values that would have panicked pre-fix.
+        for bad in [6, 7] {
+            let out = truncate(s, bad);
+            // Must not panic and must end with the ellipsis marker.
+            assert!(out.ends_with('…'), "output should signal truncation: {out}");
+            // Must be a valid UTF-8 string — `to_string()` above already
+            // enforces this, but confirm semantically: the output should NOT
+            // contain the full `≥` (truncation happens before it).
+            assert!(
+                !out.contains('≥'),
+                "output should have truncated before the multi-byte char: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn truncate_preserves_multibyte_chars_when_boundary_permits() {
+        let s = "a≥b"; // bytes: 1 + 3 + 1 = 5
+                       // max=4 snaps to byte 4 which IS a char boundary (start of 'b'),
+                       // so the output keeps `≥` and truncates before `b`.
+        let out = truncate(s, 4);
+        assert_eq!(out, "a≥…");
     }
 }

--- a/crates/specere-units/src/ears_linter/rules.toml
+++ b/crates/specere-units/src/ears_linter/rules.toml
@@ -10,16 +10,23 @@ schema_version = 1
 [[rules]]
 id = "ears-fr-prefix"
 severity = "warning"
-description = "Functional requirements SHOULD use a canonical FR-NNN (or FR-P<phase>-NNN) prefix"
+description = "Functional requirements SHOULD use a canonical FR prefix: FR-NNN, FR-P<phase>-NNN, or FR-<DOMAIN>-NNN"
 scope = "functional-requirements"
-pattern = '^\s*-\s*\*\*FR(-P\d+)?-\d{3,}\*\*:'
+# Widened in #65 to accept domain-prefixed IDs (FR-AUTH-001, FR-EDITOR-018 —
+# a very common convention). The optional `(-[A-Z][A-Z0-9]+)?` captures a
+# domain tag, keeping FR-NNN and FR-P<phase>-NNN backward-compatible. Digits
+# inside a domain (FR-OAUTH2-001) are allowed after the first letter.
+pattern = '^\s*-\s*\*\*FR(-P\d+)?(-[A-Z][A-Z0-9]+)?-\d{3,}\*\*:'
 
 [[rules]]
 id = "ears-must-should"
 severity = "warning"
-description = "FRs SHOULD contain MUST or SHOULD (capitalised) to express the requirement strength"
+description = "FRs SHOULD contain MUST, SHALL, SHOULD, or MAY to express the requirement strength"
 scope = "functional-requirements"
-pattern = '\b(MUST|SHOULD)\b'
+# Widened in #65 to include SHALL (canonical EARS imperative — Mavin et al.)
+# and MAY (canonical optional-permission verb). MUST and SHOULD retained for
+# compatibility with projects that prefer RFC-2119 phrasing.
+pattern = '\b(MUST|SHALL|SHOULD|MAY)\b'
 
 # NOTE: a prior `ears-condition-keyword` rule was removed in PR for issue #25.
 # It was dead code — pattern was the same as the `condition_only` gate, so it

--- a/crates/specere-units/src/speckit.rs
+++ b/crates/specere-units/src/speckit.rs
@@ -204,6 +204,36 @@ impl AddUnit for Speckit {
                 tracing::warn!("CLAUDE.md present but does not look SpecKit-generated; preserving");
             }
         }
+
+        // 3) Sweep orphan skill directories the upstream SpecKit integration
+        //    drops but doesn't enumerate on uninstall. Issue #64 — observed:
+        //    `speckit-git-{commit,feature,initialize,remote,validate}`
+        //    remain after `specere remove speckit` because speckit is a
+        //    wrapper unit with "0 files, 0 markers" in our manifest, and
+        //    the upstream `specify integration uninstall` hook can miss them.
+        //
+        //    Limited to `speckit-git-*` so we DON'T touch the other
+        //    `speckit-*` skills that `claude-code-deploy` installs (`speckit-plan`,
+        //    `speckit-implement`, etc.) — those are that unit's responsibility
+        //    and have their own manifest tracking.
+        let claude_skills = ctx.repo().join(".claude").join("skills");
+        if claude_skills.is_dir() {
+            if let Ok(entries) = std::fs::read_dir(&claude_skills) {
+                for entry in entries.flatten() {
+                    let name = entry.file_name();
+                    let name_str = name.to_string_lossy();
+                    if name_str.starts_with("speckit-git-") {
+                        let path = entry.path();
+                        if path.is_dir() {
+                            let _ = std::fs::remove_dir_all(&path);
+                        } else {
+                            let _ = std::fs::remove_file(&path);
+                        }
+                    }
+                }
+            }
+        }
+
         tracing::info!(
             "speckit removed (upstream integration uninstall: {})",
             if integration_removed {

--- a/crates/specere/tests/issue_025_ears_lint_cli.rs
+++ b/crates/specere/tests/issue_025_ears_lint_cli.rs
@@ -41,6 +41,88 @@ fn setup_foo_feature(repo: &TempRepo) {
 }
 
 #[test]
+fn lint_ears_accepts_ears_canonical_shall_and_domain_prefixed_ids() {
+    // Issue #65 regression — the default rules used to reject the
+    // EARS-textbook style (SHALL + FR-DOMAIN-NNN). Confirm a spec authored
+    // in the canonical style produces zero findings.
+    let repo = TempRepo::new();
+    std::fs::create_dir_all(repo.abs(".specere/lint")).unwrap();
+    repo.write(
+        ".specere/lint/ears.toml",
+        include_str!("../../specere-units/src/ears_linter/rules.toml"),
+    );
+    std::fs::create_dir_all(repo.abs(".specify")).unwrap();
+    repo.write(
+        ".specify/feature.json",
+        r#"{"feature_directory":"specs/001-ears-canonical"}"#,
+    );
+    std::fs::create_dir_all(repo.abs("specs/001-ears-canonical")).unwrap();
+    repo.write(
+        "specs/001-ears-canonical/spec.md",
+        "## Requirements\n\n### Functional Requirements\n\n\
+         - **FR-AUTH-001**: The system SHALL return HTTP 401 for unauthenticated requests.\n\
+         - **FR-AUTH-002**: When a token expires, the system SHALL refresh it automatically.\n\
+         - **FR-EDITOR-018**: The editor MAY cache the buffer.\n",
+    );
+
+    let out = repo.run_specere(&["lint", "ears"]).output().expect("spawn");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // No findings for SHALL / MAY / FR-<DOMAIN>-NNN — all three bullets are
+    // canonical EARS.
+    assert!(
+        !stdout.contains("ears-fr-prefix"),
+        "ears-fr-prefix fired on canonical FR-DOMAIN-NNN:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("ears-must-should"),
+        "ears-must-should fired on canonical SHALL/MAY:\n{stdout}"
+    );
+}
+
+#[test]
+fn lint_ears_tolerates_multibyte_utf8_in_fr_line() {
+    // Issue #63 regression — `truncate` used to slice at a byte offset
+    // landing inside a multi-byte codepoint (e.g. `≥`), panicking. Now
+    // char-boundary-safe.
+    let repo = TempRepo::new();
+    std::fs::create_dir_all(repo.abs(".specere/lint")).unwrap();
+    repo.write(
+        ".specere/lint/ears.toml",
+        include_str!("../../specere-units/src/ears_linter/rules.toml"),
+    );
+    std::fs::create_dir_all(repo.abs(".specify")).unwrap();
+    repo.write(
+        ".specify/feature.json",
+        r#"{"feature_directory":"specs/001-utf8"}"#,
+    );
+    std::fs::create_dir_all(repo.abs("specs/001-utf8")).unwrap();
+    // A pathologically long FR with multi-byte characters at positions that
+    // used to land inside the truncate window.
+    repo.write(
+        "specs/001-utf8/spec.md",
+        "## Requirements\n\n### Functional Requirements\n\n\
+         - **FR-001**: The system SHALL sample the pointer at ≥ 60 Hz → track continuously and accumulate a PathLayer — with sub-ms jitter.\n\
+         - **FR-002**: When concerns ≠ zero, THE system MUST emit an event within ≤ 10 ms.\n",
+    );
+
+    let out = repo.run_specere(&["lint", "ears"]).output().expect("spawn");
+    // Advisory lint: must not panic, must exit 0.
+    assert!(
+        out.status.success(),
+        "lint panicked on multi-byte input.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Confirm no panic leaked to stderr.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("byte index") && !stderr.contains("char boundary"),
+        "panic message leaked to stderr:\n{stderr}"
+    );
+}
+
+#[test]
 fn lint_ears_accepts_feature_dir_alias() {
     // Issue #61 regression — the parser used to only accept the full
     // `feature_directory` key name. The self-dogfood guide's T-31 scenario

--- a/crates/specere/tests/issue_064_speckit_orphan_skills.rs
+++ b/crates/specere/tests/issue_064_speckit_orphan_skills.rs
@@ -1,0 +1,109 @@
+//! Issue #64 regression — `specere remove speckit` must sweep orphan
+//! `.claude/skills/speckit-git-*` directories that the upstream speckit
+//! integration drops but doesn't enumerate on uninstall.
+//!
+//! Scope: we only claim ownership of `speckit-git-*` — other `speckit-*`
+//! skills (plan, implement, specify, etc.) belong to `claude-code-deploy`
+//! and must survive `specere remove speckit`.
+
+mod common;
+
+use common::TempRepo;
+
+fn seed_skill_dirs(repo: &TempRepo, names: &[&str]) {
+    for n in names {
+        let dir = repo.abs(&format!(".claude/skills/{n}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("SKILL.md"), "# placeholder\n").unwrap();
+    }
+}
+
+#[test]
+fn remove_speckit_sweeps_orphan_speckit_git_skills() {
+    let repo = TempRepo::new();
+    // Install speckit (no-op uvx) so the manifest has an entry to remove.
+    let out = repo
+        .run_specere(&["add", "speckit"])
+        .env("SPECERE_TEST_SKIP_UVX", "1")
+        .output()
+        .expect("spawn");
+    assert!(
+        out.status.success(),
+        "add speckit failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Simulate the orphan state: upstream integration dropped 5 skill dirs
+    // but didn't record them in its own manifest.
+    seed_skill_dirs(
+        &repo,
+        &[
+            "speckit-git-commit",
+            "speckit-git-feature",
+            "speckit-git-initialize",
+            "speckit-git-remote",
+            "speckit-git-validate",
+            // Two skills that belong to OTHER units and must be preserved.
+            "speckit-plan",
+            "specere-observe-step",
+        ],
+    );
+
+    let out = repo
+        .run_specere(&["remove", "speckit", "--force"])
+        .output()
+        .expect("spawn");
+    assert!(
+        out.status.success(),
+        "remove speckit failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // All speckit-git-* dirs must be gone.
+    for orphan in [
+        "speckit-git-commit",
+        "speckit-git-feature",
+        "speckit-git-initialize",
+        "speckit-git-remote",
+        "speckit-git-validate",
+    ] {
+        let path = repo.abs(&format!(".claude/skills/{orphan}"));
+        assert!(
+            !path.exists(),
+            "orphan {orphan} survived `specere remove speckit`"
+        );
+    }
+
+    // Non-speckit-git skills must NOT have been touched.
+    for preserved in ["speckit-plan", "specere-observe-step"] {
+        let path = repo.abs(&format!(".claude/skills/{preserved}"));
+        assert!(
+            path.exists(),
+            "non-orphan {preserved} was swept — should belong to another unit"
+        );
+    }
+}
+
+#[test]
+fn remove_speckit_is_safe_when_skills_dir_is_absent() {
+    let repo = TempRepo::new();
+    let out = repo
+        .run_specere(&["add", "speckit"])
+        .env("SPECERE_TEST_SKIP_UVX", "1")
+        .output()
+        .expect("spawn");
+    assert!(out.status.success());
+    // Explicitly ensure no .claude/skills/ exists so the sweep hits the
+    // "no entries" path.
+    let _ = std::fs::remove_dir_all(repo.abs(".claude"));
+
+    let out = repo
+        .run_specere(&["remove", "speckit", "--force"])
+        .output()
+        .expect("spawn");
+    assert!(
+        out.status.success(),
+        "remove speckit with no skills dir should succeed, got:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}


### PR DESCRIPTION
Three real bugs caught during the self-dogfood guide's extended run. All three have targeted regression tests.

## Closes #63 — `ears-lint` UTF-8 panic

\`truncate\` in \`crates/specere-units/src/ears_lint.rs\` sliced a \`&str\` at a byte offset that could land inside a UTF-8 codepoint (\`≥\`, \`→\`, \`€\`, em-dashes, smart-quotes — all common in technical specs). The panic leaked through the advisory-only contract and silently dropped every would-be finding on the affected spec.

**Fix.** \`truncate\` now snaps \`max\` back to the nearest char boundary before slicing. 4 new unit tests in \`ears_lint.rs\` + 1 end-to-end integration test exercising \`≥ → ≠ ≤ —\`.

## Closes #64 — \`specere remove speckit\` orphans

The upstream \`specify integration uninstall\` hook doesn't always enumerate the \`speckit-git-{commit,feature,initialize,remote,validate}\` skill dirs it drops, and those aren't recorded in specere's manifest (speckit is a wrapper unit). Uninstall left them behind.

**Fix.** \`Speckit::remove\` now best-effort deletes any \`.claude/skills/speckit-git-*\` directory. Deliberately does **not** sweep other \`speckit-*\` skills (\`speckit-plan\`, \`speckit-implement\`, …) — those belong to \`claude-code-deploy\` and are tracked in its manifest. New \`crates/specere/tests/issue_064_speckit_orphan_skills.rs\` with two regressions: the sweep fires on the known orphans AND preserves non-speckit-git skills.

## Closes #65 — default EARS rules reject canonical SHALL / MAY / FR-DOMAIN

Pre-fix:
- \`ears-fr-prefix\` rejected \`FR-AUTH-001\` / \`FR-EDITOR-018\` (common domain-prefix convention).
- \`ears-must-should\` rejected \`SHALL\` and \`MAY\` (canonical EARS imperatives per Mavin et al.).

Any spec authored in the EARS-textbook style false-positive'd on both rules.

**Fix.**
\`\`\`toml
[[rules]]
id = \"ears-fr-prefix\"
pattern = '^\\s*-\\s*\\*\\*FR(-P\\d+)?(-[A-Z][A-Z0-9]+)?-\\d{3,}\\*\\*:'

[[rules]]
id = \"ears-must-should\"
pattern = '\\b(MUST|SHALL|SHOULD|MAY)\\b'
\`\`\`

## Test count

**188 workspace tests** (180 → 188; +8 regressions across all three fixes).

## Release mechanics

Workspace 1.0.3 → 1.0.4. CHANGELOG \`[Unreleased]\` → \`[1.0.4] - 2026-04-19\`. Standard tag cut on merge.