### PR TITLE
docs: evidence-quality proposal + execution plan (v1.0.5 → v1.1.0)

### DIFF
--- a/docs/evidence-quality-plan.md
+++ b/docs/evidence-quality-plan.md
@@ -1,0 +1,432 @@
+# Evidence-quality execution plan (v1.0.5 → v1.1.0)
+
+**Status.** Drafted 2026-04-19. Scope + direction approved via interactive questionnaire on `docs/proposals/v2-evidence-quality.md`. No code touched yet — this plan is what lands first, reviewed, then implementation follows.
+
+**Release shape.**
+
+| Release | Slice | Scope | FRs |
+|---|---|---|---|
+| **v1.0.5** | Mutation-calibrated sensors + test-smell detector + motion-matrix-fit + suspicious-SAT review queue | ~900 LoC, no external APIs or paid services | FR-EQ-001 … FR-EQ-007 |
+| **v1.0.6** | Bug-tracker bridge (GitHub + Gitea) | ~600 LoC, requires credentials, light LLM spend for triage (embeddings) | FR-EQ-010 … FR-EQ-013 |
+| **v1.1.0** | LLM adversary agent with hard $20/mo budget | ~800 LoC + ongoing LLM spend | FR-EQ-020 … FR-EQ-024 |
+
+Each release is patch-compatible except **v1.1.0** which introduces a new CLI verb surface and bumps the minor. Patches only add event kinds + channels; the filter's public interface is unchanged.
+
+**Authority.** This plan supersedes `docs/upcoming.md` priority queue items #1–#4 (calibrate motion-fit tail, MarkerEntry compat, RBPF CLI routing, long spec-ID alignment). Those carry-over items are re-prioritised in § 10.
+
+---
+
+## 1. v1.0.5 — mutation + smells + motion + review-queue
+
+### FR-EQ-001 — `specere evaluate mutations` subcommand
+
+**Acceptance criteria.**
+
+- New `specere evaluate mutations` verb that shells out to `cargo-mutants --json --in-diff <ref>` (or `--file <paths>`) with flags for scope control.
+- Parses cargo-mutants' JSON output and emits one event per mutant to `.specere/events.jsonl`:
+  ```json
+  {
+    "ts": "<rfc3339>",
+    "source": "cargo-mutants",
+    "signal": "traces",
+    "attrs": {
+      "event_kind": "mutation_result",
+      "spec_id": "<fr-id>",
+      "outcome": "caught | missed | timeout | unviable",
+      "operator": "replace_if | flip_comparison | ...",
+      "file": "crates/.../lib.rs",
+      "line": "142"
+    }
+  }
+  ```
+- `spec_id` resolved by intersecting the mutated file's path with `[specs]` entries' `support` lists in sensor-map.toml. Same directory-boundary semantics as `specere calibrate from-git` (no cross-sibling false matches, v1.0.1 fix).
+- `--scope <fr-id>` flag to run mutation only on files supporting one FR.
+- `--jobs N` forwarded to cargo-mutants.
+- Exit 0 on success; nonzero only on infrastructure failure (missing cargo-mutants, malformed JSON).
+- Advisory per specere convention: a 40% kill rate is not an error.
+
+**Out of scope.** Installing cargo-mutants itself — assume present on PATH; clear error if missing.
+
+**Test plan.** 4 integration tests.
+- End-to-end run against a tiny Rust crate with 2 specs and ~10 mutants.
+- Scope flag correctly restricts mutants.
+- Spec-ID attribution matches expected sensor-map mapping.
+- Handles missing cargo-mutants gracefully.
+
+### FR-EQ-002 — sensor-calibration formula integrates mutation kill rate
+
+**Acceptance criteria.**
+
+- `PerSpecHMM` / `FactorGraphBP` / `RBPF` accept a new `Calibration` struct:
+  ```rust
+  pub struct Calibration {
+      pub quality: f64,        // ∈ [0.3, 1.0]
+      pub alpha_sat: f64,
+      pub alpha_vio: f64,
+      pub alpha_unk: f64,
+  }
+  ```
+- `Calibration::default()` returns prototype alphas (0.92 / 0.90 / 0.55) and `quality=1.0`. Backwards-compatible with v1.0.4 behaviour.
+- A new `Calibration::from_evidence(kill_rate, smell_penalty)` implements the formula in `docs/proposals/v2-evidence-quality.md §5`:
+  ```
+  q = clamp(0.3, kill_rate * smell_penalty, 1.0)
+  α_sat = 0.55 + q * 0.37
+  α_vio = 0.45 + q * 0.45
+  α_unk = 0.55  # unchanged
+  ```
+- `DefaultTestSensor::log_likelihood` becomes `CalibratedTestSensor` parameterised on `Calibration`. Old `DefaultTestSensor` preserved as an alias returning prototype alphas.
+- Gate-A parity fixture regenerated with `quality=1.0` to preserve bit-identical parity (FR-P4-002 anchor must still pass).
+
+**Test plan.** 3 unit tests + 1 parity refresh.
+- Prototype defaults → `quality=1.0` → alphas unchanged.
+- `kill_rate=0.3` → alphas compress: `α_sat ≈ 0.66`, `α_vio ≈ 0.59`.
+- `kill_rate=0` with `smell_penalty=0.5` → `q = 0.3` (clamped), alphas at the floor.
+- Gate-A parity test still bit-identical under the new code path.
+
+### FR-EQ-003 — `specere lint tests` detects test smells
+
+**Acceptance criteria.**
+
+- New `specere lint tests` verb that walks `src/**/*.rs` + `tests/**/*.rs`, parses with `syn`, applies a rule set:
+  - `tautological-assert` — `assert_eq!(x, x)`, `assert_ne!(x, y)` where `x == y` literally, `assert!(true)`.
+  - `no-assertion` — test fn body contains no `assert*!` / `.unwrap_err()` / `? == Err` discriminant.
+  - `mock-only` — test body is 90%+ `mock_*` macro calls, no real subject.
+  - `single-fixture` — all tests for a fn use the same input constant (happy-path only).
+- Emits `test_smell_detected` events:
+  ```json
+  {
+    "attrs": {
+      "event_kind": "test_smell_detected",
+      "spec_id": "<inferred>",
+      "smell_kind": "tautological-assert",
+      "severity": "info",
+      "test_fn": "tests/foo::smoke",
+      "file": "tests/foo.rs",
+      "line": "42"
+    }
+  }
+  ```
+- Severity is always `info` per user's choice (§ 4 answer: degrade posterior but proceed).
+- `spec_id` inferred from the test file's path via sensor-map's support sets, OR from a `// FR-NNN` comment in the test body (opt-in annotation), OR `unknown` if neither matches.
+
+**Test plan.** 6 unit tests, one per smell, + 2 integration tests covering the full pipeline on a fixture crate.
+
+### FR-EQ-004 — `specere calibrate motion-from-evidence`
+
+**Acceptance criteria.**
+
+- New subcommand `specere calibrate motion-from-evidence` (distinct from the existing `specere calibrate from-git` which produces coupling edges).
+- For each spec in `[specs]`:
+  - Walk events.jsonl + any history from `events.sqlite`.
+  - Identify `test_outcome` events with a preceding `files_touched` or `mutation_result` event.
+  - Estimate per-spec transition matrix using the Laplace-smoothed MLE described in `docs/specere_v1.md §5.P5`.
+  - Requires at least 20 events per spec to emit a fit; otherwise reports `insufficient history`.
+- Writes proposed per-spec `[motion]` table to stdout for user to paste into sensor-map.toml:
+  ```toml
+  [motion."FR-001"]
+  t_good = [[0.10, 0.80, 0.10], [...], [...]]  # or whatever the fit produces
+  t_bad  = [[0.10, 0.10, 0.80], [...], [...]]
+  t_leak = [[...], [...], [...]]
+  ```
+- `Motion::prototype_defaults()` remains the default; per-spec motion overrides it when present in sensor-map.
+- Writes a companion `[calibration]` section with `quality` from current mutation kill rate (per FR-EQ-002) so filter pick-up is one-step.
+
+**Test plan.** 3 integration tests.
+- 20+ synthetic events → per-spec motion emitted.
+- < 20 events → "insufficient history" message, no output.
+- End-to-end: `cargo-mutants` → `calibrate motion-from-evidence` → `filter run` uses fitted alphas.
+
+### FR-EQ-005 — filter-run integration
+
+**Acceptance criteria.**
+
+- `run_filter_run` loads `Calibration` per spec from the aggregation of:
+  - Mutation kill rate (aggregate all `mutation_result` events for this spec in window, default: last 30 days).
+  - Smell penalty (aggregate `test_smell_detected` — each smell compresses `smell_penalty` by 0.15, floor 0.3).
+  - Per-spec motion from sensor-map if present; else `Motion::prototype_defaults()`.
+- Emits a one-line summary per spec on `filter run`:
+  ```
+  specere filter: processed 12 event(s); calibration:
+    FR-001  kill=0.87 smells=0 q=0.87 α_sat=0.87 α_vio=0.84
+    FR-002  kill=0.45 smells=2 q=0.32 α_sat=0.67 α_vio=0.59 ← suspicious
+  ```
+- No existing tests break (FR-P4-001/003/004/006 regression anchors still green).
+- Backwards compatibility: a repo with zero mutation/smell events uses `q=1.0` (prototype defaults) — identical to v1.0.4 behaviour.
+
+**Test plan.** 3 integration tests.
+- Zero evidence events → prototype-default alphas.
+- Mutation events present → alphas compress correctly.
+- Filter run output contains calibration summary.
+
+### FR-EQ-006 — `specere doctor --suspicious` review-queue flagging
+
+**Acceptance criteria.**
+
+- `specere doctor --suspicious` scans posterior.toml + the calibration output of a hypothetical next `filter run`.
+- For each spec where `p_sat > 0.95` AND `quality < 0.5` (default thresholds; configurable in sensor-map):
+  - Append an entry to `.specere/review-queue.md`:
+    ```markdown
+    ## Suspicious high-confidence SAT — FR-001 (auto-flagged 2026-04-19)
+    
+    - **Posterior**: p_sat = 0.97, p_vio = 0.01, p_unk = 0.02
+    - **Calibration**: quality = 0.34 (mutation kill 0.40, smell penalty 0.85)
+    - **Recommendation**: Human sanity-check before trusting this SAT — either the test suite is too weak to discriminate, or smells are dragging calibration down.
+    ```
+- Never auto-removes entries — manual review is the adjudication (constitution V).
+- Thresholds configurable in `sensor-map.toml`:
+  ```toml
+  [review]
+  suspicious_p_sat_min = 0.95
+  suspicious_quality_max = 0.50
+  ```
+
+**Test plan.** 2 integration tests (suspicious spec flagged, confident spec ignored).
+
+### FR-EQ-007 — additive event schema
+
+**Acceptance criteria.**
+
+- Events with new `event_kind` values (`mutation_result`, `test_smell_detected`, `bug_reported`, `counterexample_found`, `adversary_budget_exhausted`) parse cleanly in the existing event-store pipeline.
+- Unknown-to-filter event kinds continue to be counted in `skipped` (existing behaviour preserved).
+- Cursor semantics unchanged — new events advance the cursor exactly like old ones.
+- Forward-compat fixture test: a posterior.toml written by v1.0.5 loads cleanly in v1.0.4 (and vice versa) via `#[serde(default)]` + `#[serde(alias)]` as already established.
+
+**Test plan.** 1 cross-version round-trip test.
+
+---
+
+## 2. v1.0.6 — bug-tracker bridge
+
+### FR-EQ-010 — `specere observe watch-issues`
+
+**Acceptance criteria.**
+
+- New verb `specere observe watch-issues --provider {github,gitea} --repo <owner/name>` that polls the issue endpoint every 10 minutes (configurable via `--interval`).
+- Credentials via env: `GITHUB_TOKEN`, `GITEA_TOKEN`; error cleanly if absent.
+- For each new issue since the cursor in `.specere/issues-cursor.toml`:
+  - Skip if label in `{question, docs, duplicate, not-planned}` or state is `closed` without a linked PR.
+  - Otherwise emit a `bug_reported` event (see FR-EQ-012 for attrs).
+- Gitea's `GET /repos/{owner}/{repo}/issues?state=open&since=<ts>` is compatible with GitHub's shape — implementation shares code.
+- Backgrounded via `--daemon` or one-shot via `--once` (default: `--once` for CI use).
+
+**Test plan.** 3 integration tests, each with a mock HTTP server (`mockito` or `wiremock-rs`) serving canned GitHub/Gitea responses.
+
+### FR-EQ-011 — LLM issue-to-spec triage
+
+**Acceptance criteria.**
+
+- A new library module `specere-filter::triage` that takes an issue body + sensor-map's `[specs]` and returns the most likely `spec_id`.
+- Approach: embed issue body with a local model (or remote API), cosine-match against each spec's `description` / `support` file contents, LLM-rerank top 3.
+- Configurable via `sensor-map.toml`:
+  ```toml
+  [triage]
+  embedder = "openai:text-embedding-3-small"  # or "local:<path>"
+  reranker = "anthropic:claude-3-5-haiku"
+  min_confidence = 0.60  # if highest match < this, emit spec_id="unknown"
+  ```
+- No triage if LLM APIs aren't configured — falls back to heuristic (stack-trace file path parse + CODEOWNERS match) with lower confidence.
+- Cost cap: configurable `max_monthly_spend_usd` (default $5 — triage is cheap).
+
+**Test plan.** 3 tests — fixtures with known-good triage, heuristic-only fallback, over-budget handling.
+
+### FR-EQ-012 — `bug_reported` event feeds posterior with decay
+
+**Acceptance criteria.**
+
+- Event attrs: `spec_id`, `issue_url`, `severity=critical|major|minor`, `age_days`, `state=open|closed`.
+- Filter-run treats each open `bug_reported` as a VIO injection with magnitude scaled by severity: critical=0.3, major=0.15, minor=0.05.
+- Exponential decay with 50-day half-life (per Kim '07 empirical optimum) — an event from day 100 counts 1/4 as much as a fresh one.
+- Closed bugs (state=closed + linked PR merged) decay faster (25-day half-life) — the fix itself is the adjudication.
+- No double-counting: a bug reported AND fixed AND closed produces one "VIO then SAT" trajectory, not two independent events.
+
+**Test plan.** 3 integration tests covering decay math, severity scaling, and open→closed state change.
+
+### FR-EQ-013 — cursor handles filesystem + remote events
+
+**Acceptance criteria.**
+
+- `posterior.toml` gains a new optional `cursors` table:
+  ```toml
+  cursor = "2026-04-19T14:00:00Z"              # legacy single cursor
+  [cursors]
+  events_jsonl = "2026-04-19T14:00:00Z"
+  github_issues = "2026-04-19T13:55:00Z"
+  gitea_issues = "2026-04-19T14:01:00Z"
+  ```
+- Single-cursor repos upgrade-in-place: on first read, the legacy cursor becomes `cursors.events_jsonl`.
+- `specere filter run` advances all cursors to their respective source's latest ts.
+
+**Test plan.** 2 round-trip tests (v1.0.5 → v1.0.6 upgrade; mixed-source event consumption).
+
+---
+
+## 3. v1.1.0 — LLM adversary agent
+
+### FR-EQ-020 — `specere adversary run --spec FR-NNN`
+
+**Acceptance criteria.**
+
+- New verb `specere adversary run --spec FR-NNN` (or `--all` for batch mode).
+- Reads the FR text from `specs/<feature>/spec.md`, the spec's support files, and the test files that exercise them.
+- Iterative loop:
+  1. Send `(spec text, support files, existing tests)` to an LLM with a prompt asking for "one input / scenario that would violate this spec if the implementation were naive or buggy."
+  2. Extract the proposed test case.
+  3. Run it in a sandbox (see FR-EQ-024).
+  4. If it fails → minimize (delta-debug) → emit `counterexample_found` event.
+  5. If it passes → go to step 1 with a different angle (up to N iterations).
+- Budget tracked in `.specere/adversary-budget.toml`:
+  ```toml
+  month = "2026-04"
+  spent_usd = 3.47
+  cap_usd = 20.0
+  ```
+- On cap hit: emit `adversary_budget_exhausted` for the current spec + any skipped specs; exit 0 with a clear message.
+
+**Test plan.** 5 integration tests — covering a synthetic broken spec (adversary finds it), a correct spec (adversary exhausts iterations, emits budget_exhausted), budget cap enforcement, model output parsing edge cases, minimization correctness.
+
+### FR-EQ-021 — hard $20/month ceiling with deferral
+
+**Acceptance criteria.**
+
+- Monthly cap of $20 default, configurable in `sensor-map.toml`:
+  ```toml
+  [adversary]
+  cap_usd_per_month = 20.0
+  model = "anthropic:claude-sonnet-4-6"
+  max_iterations = 5
+  ```
+- `spent_usd` incremented after each LLM call using the API's `usage.total_cost` or a local computation from token counts.
+- Budget rolls over on the 1st of each month (local TZ).
+- `specere adversary status` prints current `spent_usd / cap_usd` + est iterations remaining.
+- Attempting to run when `spent_usd >= cap_usd` exits with a clear message naming the cap; exit code 2 (distinct from other errors).
+
+**Test plan.** 3 integration tests (cap-not-hit, cap-hit, roll-over).
+
+### FR-EQ-022 — ≥ 3-iteration rule before posterior update
+
+**Acceptance criteria.**
+
+- A counterexample is only written to events.jsonl if:
+  - The falsification loop ran ≥ 3 iterations before finding it (one-shot findings are suspect per Liu '24).
+  - The counterexample reproduces deterministically (the test runs twice with the same input + gets the same failure).
+- Single-iteration findings are recorded as `counterexample_candidate` (not `counterexample_found`) and surfaced to review queue for human judgment, not posterior update.
+
+**Test plan.** 2 integration tests covering first-iter-find (candidate only) vs third-iter-find (posterior update).
+
+### FR-EQ-023 — counter-example minimization
+
+**Acceptance criteria.**
+
+- Delta-debugging loop on a found counterexample to produce the minimal input that still fails.
+- Record both the original and minimized form in the event attrs.
+- Minimization is time-boxed (30 s default) — if it doesn't converge, record the original.
+
+**Test plan.** 2 integration tests on a small fixture.
+
+### FR-EQ-024 — sandbox for LLM-generated test code
+
+**Acceptance criteria.**
+
+- LLM-generated test code runs in a container or process-isolated subprocess with:
+  - No network access.
+  - Read-only access to the repo files.
+  - Write access to a scratch dir only.
+  - 30 s wall-clock timeout.
+  - Resource limits (256 MB memory, 1 CPU).
+- On escape attempt or timeout: emit `adversary_sandbox_violation` event (distinct from a successful counter-example); do NOT update posterior.
+
+**Test plan.** 4 integration tests — normal run, timeout, memory limit, network attempt.
+
+---
+
+## 4. Dependency graph
+
+```
+v1.0.5                v1.0.6                v1.1.0
+┌───────────────┐    ┌───────────────┐    ┌───────────────┐
+│ mutation +    │───▶│ bug-tracker   │───▶│ adversary     │
+│ smells +      │    │ bridge        │    │ agent         │
+│ motion fit +  │    │ (GitHub,      │    │ ($20 cap,     │
+│ review queue  │    │  Gitea local) │    │  sandbox)     │
+└───────────────┘    └───────────────┘    └───────────────┘
+   Calibration          Independent          Active falsification;
+   machinery.           evidence channel;    consumes v1.0.5's
+   Enables weighted     decay-weighted;      calibration to weigh
+   posterior under      works with or        its own output.
+   weak tests.          without LLM triage.
+```
+
+Each slice depends on its left neighbour:
+- v1.0.6 reuses v1.0.5's `Calibration` struct + event schema.
+- v1.1.0 needs v1.0.5 to damp its hallucination-prone output AND v1.0.6 to cross-check its findings ("did this counterexample also trigger a real bug report?").
+
+## 5. Re-planning triggers
+
+- **Mutation runtime > 30 min** on a medium crate. Pause, move to nightly-only mode for FR-EQ-001.
+- **LLM triage false-positive rate > 40%** measured on a labelled sample. Pause FR-EQ-011, fall back to heuristics until we can improve.
+- **Adversary budget burn > $5 in first week** on a typical repo. Pause FR-EQ-020, tighten `max_iterations` default to 3, re-evaluate.
+- **Bit-identical Gate-A parity breaks** when refactoring `DefaultTestSensor` → `CalibratedTestSensor`. Hard stop; the FR-P4-002 anchor is non-negotiable.
+- **Review-queue noise** (> 5 false-alarm suspicious flags per session). Adjust thresholds; if that doesn't fix it, the calibration formula needs revision.
+
+## 6. Exit criteria
+
+**v1.0.5 ships when:**
+- All FR-EQ-001 … FR-EQ-007 acceptance criteria met.
+- Workspace tests +25 minimum.
+- `specere evaluate mutations` runs clean on specere's own repo and produces per-spec kill rates.
+- Gate-A parity (FR-P4-002) bit-identical under the new `CalibratedTestSensor` code path.
+- CHANGELOG rolled; self-dogfood guide updated with a new part exercising `evaluate mutations` + `lint tests` + the review queue.
+
+**v1.0.6 ships when:**
+- FR-EQ-010 … FR-EQ-013 met.
+- Mock-HTTP integration tests for both GitHub + Gitea.
+- Credential handling is secret-safe (no tokens in CHANGELOG, test fixtures, or logs).
+
+**v1.1.0 ships when:**
+- FR-EQ-020 … FR-EQ-024 met.
+- Sandbox fuzzed against a test-suite of malicious-LLM-output scenarios (attempted `curl`, `rm -rf /`, fork-bomb, network probe) with all blocked.
+- $20 cap verified via a stubbed API returning high-cost responses until cap hits.
+
+## 7. Test surface estimates
+
+- v1.0.5: ~25 new tests (6 mutation-verb, 3 sensor calibration, 8 smell rules, 3 motion-fit, 3 filter-run integration, 2 review-queue).
+- v1.0.6: ~11 new tests (3 watch-issues, 3 triage, 3 decay, 2 cursor-compat).
+- v1.1.0: ~16 new tests (5 adversary-run, 3 budget, 2 iteration rule, 2 minimization, 4 sandbox).
+
+Total projected: ~52 new tests. Current baseline: 188. Target post-v1.1.0: ~240.
+
+## 8. External dependencies
+
+- **v1.0.5**: `cargo-mutants` (run-time only, not a cargo dep). `syn` (already an indirect dep).
+- **v1.0.6**: `reqwest` (already a dep). Possibly `wiremock` (test-only). Optional LLM client (`anthropic-sdk`?).
+- **v1.1.0**: LLM client (`anthropic-sdk` or `reqwest` + manual). `nix` or `bollard` for sandboxing (investigate both; `nsjail`/`bubblewrap` are Linux-only, need macOS/Windows story).
+
+## 9. User-facing docs per slice
+
+- v1.0.5: new section in `docs/filter.md` on "sensor calibration" + a new `docs/test-plans/` scenario set for the mutation/smell pipeline.
+- v1.0.6: new doc `docs/bug-tracker-integration.md` covering providers, credentials, triage config.
+- v1.1.0: new doc `docs/adversary-agent.md` covering budget, sandbox model, how to interpret counterexamples, and the ≥ 3-iteration damping rule.
+
+## 10. Re-prioritisation of prior carry-overs
+
+Current `docs/upcoming.md` items get re-sorted:
+
+| Old priority | Item | New placement |
+|---|---|---|
+| #1 | MarkerEntry backwards-compat | Parked — affects only one old committed manifest; low value vs v1.0.5 |
+| #2 | Motion-matrix-fit from (diff, test-delta) | **Subsumed by FR-EQ-004** in v1.0.5 |
+| #3 | RBPF CLI routing | Parked — no user requested it yet |
+| #4 | Long spec-ID table alignment | Parked — cosmetic, JSON output works |
+
+After v1.1.0 ships, revisit whether any of these are still worth the effort given real-world evidence-quality data.
+
+## 11. Immediate next steps
+
+1. **Review + merge this plan + the proposal doc** (one PR). No code touched.
+2. **File three tracking issues** — one per release slice — each referencing this plan and listing its FRs.
+3. **v1.0.5 sub-issues** — FR-EQ-001 through FR-EQ-007, each a sub-issue of the v1.0.5 tracker.
+4. **Start FR-EQ-001** as the first PR. Every subsequent FR-EQ-NNN PR closes its issue and references this plan.
+
+---
+
+*This plan lives at `docs/evidence-quality-plan.md`. Paired with `docs/proposals/v2-evidence-quality.md` (the research + design doc). Both land as one PR for reviewer context.*

--- a/docs/proposals/v2-evidence-quality.md
+++ b/docs/proposals/v2-evidence-quality.md
@@ -1,0 +1,217 @@
+# Proposal: evidence-quality channels for SpecERE v2
+
+**Status.** Draft, 2026-04-19. Awaiting user direction before we plan execution.
+**Author.** Generated from user request + three parallel research passes (mutation testing, LLM adversarial generation, bug-tracker-as-telemetry). See § 8 References for URLs.
+**Audience.** Project maintainers. This is a *design* document, not an implementation plan — implementation lands after the open questions in § 7 are resolved.
+
+---
+
+## 1. The problem, stated precisely
+
+The SpecERE filter's posterior is only as trustworthy as the evidence feeding it. v1 has one calibrated sensor channel (Channel A: test pass/fail) with fixed constants:
+
+```
+P(pass | SAT) = α_sat = 0.92    # prototype default
+P(fail | VIO) = α_vio = 0.90
+P(pass | UNK) = α_unk = 0.55
+```
+
+These constants assume the test suite has **high discriminative power** — tests pass when the spec is satisfied and fail when it's violated. That assumption fails in three common modes:
+
+| Failure mode | What happens | Effect on posterior |
+|---|---|---|
+| **Tautological tests** | `assert_eq!(x, x)`, over-mocking, missing assertions | `P(pass\|SAT) ≈ P(pass\|VIO)` → no signal; posterior stays near uniform even under heavy evidence |
+| **Happy-path-only coverage** | Only the golden path exercised; edge cases untested | `P(pass\|VIO)` is close to `P(pass\|SAT)` → false confidence (inflated p_sat) |
+| **Wrong tests (test bug)** | The test is checking the wrong property | Posterior converges to a satisfying belief for a wrong condition |
+
+Combined with the fact that tests **can be wrong in ways we can't detect from their pass/fail alone**, this creates a systematic gap between the posterior and reality. A spec can reach `p_sat > 0.95` while being completely broken — the exact failure mode the user observed on an agentic-created repo.
+
+Three orthogonal evidence channels the user proposed:
+
+1. **Test-suite quality as sensor calibration.** Weak tests → looser sensor model → less confident posterior.
+2. **Bug reports as an independent VIO channel.** A bug filed against code under a spec's support set is strong evidence of violation, regardless of what tests say.
+3. **Adversarial agents that try to falsify SAT estimates.** If a "prove-me-wrong" agent can't find a counter-example despite trying hard, that's stronger evidence than a passive passing test suite.
+
+This maps onto the original sensor-channel design in `docs/analysis/core_theory.md §3` (ReSearch): v1 activated channels A (tests), B (reads), C (harness-intrinsic). Channel D was deliberately deferred and documented as "invariants / PBT / mutation." The user's request activates Channel D and adds new channels E (bug reports) and F (adversary agents) that v1 didn't anticipate.
+
+## 2. What the research found
+
+Three parallel research passes. Full summaries + URLs in § 8. Headlines:
+
+### 2.1 Mutation testing
+
+- **`cargo-mutants`** (Martin Pool) is mature, `--json` output, per-file scoping (`--file`, `--re`), `--in-diff` for incremental PR runs. Nightly-full + per-PR-diff is the common pattern.
+- **Empirical basis**: Just et al. (FSE 2014) — mutation score correlates with real-fault detection at **r ≈ 0.72**, vs r ≈ 0.44 for statement/branch coverage. Papadakis et al. (2018) confirms across multiple languages.
+- **Practical target**: >80% kill rate on changed code; 90%+ for safety-critical. Absolute scores are less meaningful than per-spec deltas.
+- **Speed**: `--in-diff` under 5 min typical; `--file <fr-support>` minutes. Full runs hours on medium crates.
+- **Zero OTel prior art** — emitting mutation results as OTel spans is greenfield. Closest schema: the cross-tool `mutation-testing-elements` JSON (Stryker ecosystem).
+
+### 2.2 LLM adversarial / counter-test generation
+
+- **Meta TestGen-LLM** (arXiv:2402.09171): 75% correct builds, 57% pass reliably, 25% improve coverage, 73% accepted by Meta engineers. **Java only.**
+- **Fuzz4All / TitanFuzz** (ICSE '24, ISSTA '23/'24): LLM-guided grey-box fuzzing found **98 new bugs across 9 systems, 64 CVEs**. The "spec + seed → unusual-but-valid input" pattern.
+- **SWE-agent** (NeurIPS '24, arXiv:2405.15793): iterative falsification at **~$1.20–$2.80 per issue** with Claude Sonnet; 65% first-try → 3-iter reproducer generation rate.
+- **Hallucination risk**: 18–31% of LLM-generated assertions test properties *not* in the spec (Schäfer et al. TSE '24). Liu et al. (ICSE '24): test validity drops from 73% → 34% under spec paraphrase.
+- **No Rust-specific production tool exists.** The composable stack is `proptest` + LLM-generated `Strategy` + SWE-agent-style loop with a hard budget and ≥ 3-iteration rule.
+
+### 2.3 Bug-tracker as telemetry
+
+- **Traceability literature** (Cleland-Huang 2014, CoEST community): defect-to-requirement linkage is a canonical relation; only ~40% of issues link explicitly, the rest need inference (stack-trace parsing, NER, CODEOWNERS matching).
+- **Signal-to-noise**: Herzig et al. (ICSE '13) — **33.8% of issues labeled "bug" are misclassified** (feature, refactor, question). 15–30% duplicates typical. Filtering heuristics (repro-step regex, non-question labels, stack-trace presence) help.
+- **Time decay**: Kim et al. (ICSE '07) — ~50-day half-life optimal on Eclipse/Mozilla fault-prediction. Bug-tracker evidence should decay exponentially against this scale.
+- **LLM triage**: GPT-4 at **82% F1** on bug/feature/question classification (MSR '24). Spec-violation mapping specifically has no public precedent but is structurally identical to solved problems.
+- **APIs**: GitHub timeline + `Fixes #N` parsing is cheap; Jira Smart Commits + Linear GraphQL equivalents exist. Polling `since=` every N minutes is simpler than webhooks for hour-scale belief updates.
+
+## 3. Design space — 6 approaches
+
+Each has different scope, cost, and epistemic value. Not all need to ship together.
+
+### Approach A: Mutation-testing Channel D (the already-planned extension)
+
+- **What.** Wrap `cargo-mutants --json --in-diff` behind a `specere evaluate mutations` verb. Aggregate kill rate per FR via the sensor-map. Emit one span per mutant: `event_kind=mutation_result`, attrs: `spec_id`, `outcome=caught|missed|timeout|unviable`, `operator`, `file`, `line`.
+- **Sensor integration.** Feed per-spec kill rate into a new `alpha_sat(spec_id)` calibration: high kill rate ⇒ near-default 0.92; low kill rate ⇒ compressed toward 0.55. Exact formula in § 5.
+- **Cost.** Dev: ~300 LoC + fixture. Runtime: 5–15 min per PR via `--in-diff`.
+- **Blocker**: requires a test suite that runs reliably — not always true for flaky / slow agentic repos.
+
+### Approach B: Property-based testing Channel D
+
+- **What.** Skill `specere-pbt-driver` that discovers `#[proptest]` / `#[quickcheck]` attributes in `tests/`, runs them, records trial count + shrunk counter-example. `event_kind=pbt_result`, attrs: `spec_id`, `trials_ok`, `failure_input`.
+- **Sensor integration.** A surviving property → weak SAT evidence (absence-of-counterexample). A shrunk counterexample → strong VIO evidence.
+- **Cost.** Dev: ~200 LoC if the repo already uses proptest; ~500 LoC with scaffolding to generate strategies.
+- **Blocker**: Rust repos vary wildly in PBT adoption. Many have zero proptest coverage.
+
+### Approach C: LLM adversary agent
+
+- **What.** New agent `specere-adversary` (subagent, not skill — long-running and context-heavy). Inputs: a spec's FR text + its support files + current passing tests. Output: a set of proposed failing inputs / test cases. Pass an iterative falsification loop (up to 5 iterations, hard $2 budget). Each iteration: generate → run in sandbox → if pass, retry with different angle; if fail, minimize + emit `event_kind=counterexample_found`.
+- **Sensor integration.** A confirmed counter-example is VIO evidence roughly equivalent to a real bug report. Budget-exhausted-without-finding is weak SAT evidence.
+- **Cost.** Dev: ~800 LoC (agent harness + sandbox + minimizer). Runtime: $1–$5 per FR per run. Damping: require ≥ 3 iterations before any posterior update (hallucination guard per Liu '24).
+- **Blocker**: sandbox correctness (running LLM-generated code must not escape), hallucination rate (damping only reduces it).
+
+### Approach D: Bug-tracker bridge (Channel E)
+
+- **What.** New subcommand `specere observe watch-issues --provider github --repo owner/name`. Polls `GET /issues?since=<cursor>` every 10 minutes. For each new issue: filter (is-bug-label? has-repro? not-duplicate?), LLM-triage which spec it hits (embeddings + rerank), emit `event_kind=bug_reported`, attrs: `spec_id`, `severity`, `issue_url`, `age_days`.
+- **Sensor integration.** Independent VIO channel with exponential decay (50-day half-life default). A closed issue decays faster than an open one. Severity scales the update magnitude.
+- **Cost.** Dev: ~600 LoC + credentials story. GitHub only in v1; GitLab/Linear/Jira in v2.
+- **Blocker**: false-positive rate (33.8% misclassification + 15–30% dupes). LLM-triage cost: pennies per issue but adds up on high-traffic projects.
+
+### Approach E: Test-smell static analysis
+
+- **What.** A new `specere lint tests` that statically analyzes tests for known smells: tautological assertions, no-assertion tests, over-mocked (all-mock) tests, happy-path-only (single fixture per fn). For each smell detected, degrade the sensor alphas for that spec's tests when the filter runs.
+- **Sensor integration.** Per-spec `quality_multiplier` ∈ [0.3, 1.0] applied to `α_sat − α_vio` difference. Low multiplier compresses the sensor toward uninformative.
+- **Cost.** Dev: ~400 LoC (rust-syntax-tree walker + rule engine). No runtime cost (static).
+- **Blocker**: false-positive smell detection. Some "tautological" tests are intentional (e.g., serialization round-trip).
+
+### Approach F: Human-in-the-loop adjudication
+
+- **What.** Extend the existing review-queue pattern (constitution V) to surface "high-posterior + suspicious evidence" specs for human sanity-check. E.g., `p_sat > 0.95` with `mutation_kill_rate < 0.4` → add to `.specere/review-queue.md` with "passive confidence but weak evidence" flag.
+- **Sensor integration.** No direct posterior change — this is a UX gate, not an evidence channel. But the user's sign-off (or "actually, broken") becomes a high-confidence manual event.
+- **Cost.** Dev: ~100 LoC.
+- **Blocker**: none; this is orthogonal polish.
+
+## 4. Recommended approach — staged integration
+
+The user asked for **one** upgrade. The right shape, combining the three concerns raised (weak tests / bug reports / counter-testing agents) into a coherent v1.1 → v2.0 arc:
+
+**v1.1 — Mutation as calibration (Approach A + E + F).** The foundation. Introduces the "sensor alphas are computed per-spec" machinery that everything else plugs into. Scope: ~900 LoC. Ships a working "weak tests degrade confidence" story without any LLM cost or external API.
+
+**v1.2 — Bug-tracker bridge (Approach D).** An independent evidence channel — high ROI because it activates the existing event pipeline with zero filter-engine changes. Scope: ~600 LoC. Requires GitHub credentials but no paid APIs beyond GitHub.
+
+**v2.0 — Adversary agent (Approach C).** The biggest and most ambitious. Relies on v1.1's calibration machinery to weigh its output correctly. Has real sandbox + hallucination risks. Scope: ~800 LoC + ongoing LLM spend.
+
+Property-based testing (Approach B) is deferred because adoption is uneven across Rust repos; it becomes a Channel D variant users can opt into when they have proptest coverage.
+
+Total: ~2300 LoC across three minor releases over ~6 sessions. Each release is independently useful.
+
+## 5. Sensor calibration formula — concrete proposal
+
+Given a spec `s` at time of filter run, compute per-spec alphas from per-channel evidence:
+
+```
+kill_rate(s)        ∈ [0, 1]    # Channel D: mutation kill rate
+smell_penalty(s)    ∈ [0, 1]    # Channel E-static: 1.0 = no smells, 0.3 = severe
+bug_density(s, t)   ∈ [0, ∞)    # Channel E-runtime: decay-weighted bugs/month
+adversary_flag(s)   ∈ {0, 1}    # Channel F: was a counter-example found?
+
+# Baseline alphas from prototype
+α_sat_0 = 0.92
+α_vio_0 = 0.90
+α_unk_0 = 0.55
+
+# Effective test quality — clamp to [0.3, 1.0] so a broken test suite
+# doesn't disable evidence entirely (still tracks UNK → SAT drift slowly).
+q(s) = clamp(0.3, kill_rate(s) * smell_penalty(s), 1.0)
+
+# Sensor compression: weak tests pull α_sat and α_vio toward α_unk.
+α_sat(s) = α_unk_0 + q(s) * (α_sat_0 - α_unk_0)    # 0.55 + q*(0.37)
+α_vio(s) = 1 - α_unk_0 + q(s) * (α_vio_0 - (1 - α_unk_0))    # 0.45 + q*(0.45)
+
+# Bug density is a pure VIO injection — independent of test-quality.
+# Modeled as a direct posterior nudge, not via the sensor alphas.
+# (Decay-weighted per-event update through channel E; see § 6.)
+
+# Adversary counter-example is a high-confidence VIO event —
+# same treatment as a bug report with severity=critical.
+```
+
+This preserves v1 behaviour exactly when kill rate = 1.0 and no smells (`q = 1.0` ⇒ alphas at prototype defaults). It smoothly compresses toward uninformative as quality drops.
+
+## 6. Event schema additions
+
+Proposed `event_kind` values for the event store:
+
+| `event_kind` | Required attrs | Channel | Treatment |
+|---|---|---|---|
+| `test_outcome` | `spec_id`, `outcome=pass\|fail` | A | existing |
+| `files_touched` | `paths` | motion | existing |
+| `mutation_result` | `spec_id`, `outcome=caught\|missed\|timeout\|unviable`, `operator`, `file`, `line` | D | aggregate to `kill_rate` |
+| `test_smell_detected` | `spec_id`, `smell_kind`, `severity`, `test_fn` | E-static | aggregate to `smell_penalty` |
+| `bug_reported` | `spec_id`, `issue_url`, `severity=critical\|major\|minor`, `age_days` | E-runtime | VIO injection with decay |
+| `counterexample_found` | `spec_id`, `input_minimized`, `test_fn`, `iterations`, `cost_usd` | F | VIO injection |
+| `adversary_budget_exhausted` | `spec_id`, `iterations`, `cost_usd` | F | weak SAT signal |
+
+All new event kinds are additive. Events with unknown `event_kind` continue to be counted in `skipped` (existing behaviour).
+
+## 7. Open questions — please answer before we plan execution
+
+1. **Scope for the first slice.** Do we tackle v1.1 (mutation + smells) alone as one PR, or bundle in v1.2 (bug-tracker) to ship a bigger story?
+2. **LLM cost ceiling.** If we build Approach C later, do you want a hard monthly budget (e.g. "≤ $20/month across all adversary runs"), a per-PR budget, or deferred-until-proven? Free tier is adversary-disabled.
+3. **Test-smell severity.** Should `assert_eq!(x, x)` be an ERROR (block `filter run` until the test is fixed) or INFO (degrade posterior but proceed)? I lean INFO — the filter's whole job is "honest about uncertainty."
+4. **Bug-tracker provider priority.** GitHub first is obvious. Beyond that: Linear? Jira? GitLab? Which matters most to your real targets (specere itself, ReSearch, memaso, any others)?
+5. **Human-in-loop adjudication UX.** The review-queue pattern works for divergence adjudication today. Extend that, or a new `specere doctor --suspicious` verb, or both?
+6. **Motion calibration integration.** v0.5.0 shipped coupling-edge calibration from git; the corresponding motion-matrix fit was deferred because "we don't have test-history." Mutation + bug-tracker channels give us that history. Should v1.1 ALSO finally wire up `specere calibrate motion-from-evidence`? It's a natural companion.
+7. **Proposal-to-implementation gate.** Once questions 1–6 are answered, do you want me to produce a full FR-numbered execution plan (like Phase 4's) for review before touching code, or go straight from here to an implementation PR?
+
+## 8. References
+
+**Mutation testing**
+- Martin Pool, `cargo-mutants`: https://github.com/sourcefrog/cargo-mutants
+- Stryker mutation-testing-elements schema: https://github.com/stryker-mutator/mutation-testing-elements
+- Just et al., "Are Mutants a Valid Substitute for Real Faults?" FSE 2014: https://people.cs.umass.edu/~rjust/publ/mutants_real_faults_fse_2014.pdf
+- Papadakis et al., "Mutation Testing Advances" (2018): https://doi.org/10.1016/bs.adcom.2018.03.015
+- Petrović & Ivanković, "State of Mutation Testing at Google" ICSE-SEIP 2018: https://research.google/pubs/pub46584/
+
+**LLM adversarial testing**
+- Alshahwan et al., "Automated Unit Test Improvement using LLMs at Meta" (TestGen-LLM): https://arxiv.org/abs/2402.09171
+- Yang et al., "SWE-agent" NeurIPS '24: https://arxiv.org/abs/2405.15793
+- Xia et al., "Fuzz4All" ICSE '24: https://arxiv.org/abs/2308.04748
+- Deng et al., "TitanFuzz" ISSTA '23: https://arxiv.org/abs/2304.02014
+- Schäfer et al., "LLM-based test-generation reliability" TSE '24
+- Liu et al., "Test validity under spec paraphrase" ICSE '24: https://arxiv.org/abs/2305.01210
+
+**Bug-tracker as telemetry**
+- Cleland-Huang et al., "Software Traceability" FOSE 2014
+- Herzig et al., "It's Not a Bug, It's a Feature" ICSE 2013: https://doi.org/10.1109/ICSE.2013.6606585
+- Zhou et al., "BugLocator" ICSE 2012: https://doi.org/10.1109/ICSE.2012.6227210
+- Śliwerski-Zimmermann-Zeller, "SZZ algorithm" MSR 2005: https://doi.org/10.1145/1083142.1083147
+- Kim et al., "Predicting Faults from Cached History" ICSE 2007
+- Lee et al., "LLM-based Bug Report Classification" MSR 2024
+- CoEST community: https://coest.org
+- OTel CI/CD Semantic Conventions: https://opentelemetry.io/docs/specs/semconv/cicd/
+
+## 9. What happens next
+
+I'll now use the interactive questionnaire (AskUserQuestion) to walk through the six open questions in § 7. Your answers become the basis for the actual execution plan — mirrors the Phase 4 pattern where the plan doc lands *before* any code.
+
+---
+
+*This proposal is a read-only research artefact. No code has been touched. The document lives at `docs/proposals/v2-evidence-quality.md` (uncommitted until we agree on scope).*


### PR DESCRIPTION
[skip-docs]

Research + design work in response to your observation that weak or wrong testing creates a systematic gap between specere's posterior and reality.

## What's in this PR

Two docs, no code:

- **`docs/proposals/v2-evidence-quality.md`** — the research synthesis (mutation testing / LLM adversarial / bug-tracker telemetry) + 6 design approaches with tradeoffs. Backed by published benchmarks (Just FSE'14 r≈0.72, Meta TestGen-LLM 75% correct / 25% coverage gain, Herzig ICSE'13 33.8% mislabel rate, Kim '07 50-day half-life).
- **`docs/evidence-quality-plan.md`** — FR-numbered execution plan (FR-EQ-001 … FR-EQ-024) across three staged releases. Each FR has acceptance criteria, test plan, and dependency mapping.

## Release shape

| Release | Scope | LoC | Novel cost |
|---|---|---|---|
| **v1.0.5** | Mutation calibration + test smells + motion fit + suspicious-SAT review queue | ~900 | none |
| **v1.0.6** | Bug-tracker bridge (GitHub + Gitea) | ~600 | LLM triage (/mo cap) |
| **v1.1.0** | LLM adversary agent ($20/mo hard cap) | ~800 | adversary LLM calls |

## Core design decision

The v1 filter hardcodes `α_sat = 0.92`. This assumes tests have discriminative power. The proposal introduces per-spec `Calibration` computed from mutation kill rate + test-smell penalty. Weak tests compress alphas toward uninformative — the filter admits its own uncertainty instead of reporting false confidence.

v1.0.5's `CalibratedTestSensor` preserves bit-identical Gate-A parity (FR-P4-002 anchor) when calibration is at defaults, so this is backwards-compatible.

## Key choices, per your questionnaire

- **Release shape**: v1.0.5/v1.0.6 as patches, v1.1.0 minor for adversary (new CLI surface).
- **Adversary cost**: hard $20/month ceiling with defer-overspend.
- **Bug tracker providers**: GitHub + Gitea (local).
- **Test smells**: INFO severity (degrade posterior, don't block).
- **Review queue**: flag high-confidence SAT with low evidence quality.
- **Motion-matrix-fit**: folded into v1.0.5 (FR-EQ-004) since mutation results give us the test-history source the original Phase 5 tail was waiting on.
- **FR-numbered plan**: this PR.

## What happens after merge

Follow-up PRs implement each FR-EQ-NNN separately, referencing this plan. First one will be FR-EQ-001 (`specere evaluate mutations` subcommand).

Review focus: is the recommended release staging (three tiny steps) the right level of risk for the direction you want to take?
