### PR TITLE
feat(evaluate): specere evaluate mutations (FR-EQ-001, closes #70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to SpecERE will be documented here. The format follows [Keep
 
 ## [Unreleased]
 
+### Added (v1.0.5 prep — evidence-quality, FR-EQ-001)
+- **`specere evaluate mutations` subcommand** ([#70](https://github.com/laiadlotape/specere/issues/70)). First slice of the evidence-quality upgrade (tracker #69). Wraps `cargo mutants --json` with per-spec scoping (`--scope FR-NNN` or `--in-diff <REF>`) and emits one `mutation_result` event per mutant into `.specere/events.jsonl`. Attribution uses the same directory-boundary semantics as the calibrate path (v1.0.1 fix — `src/auth` doesn't false-match `src/auth_helpers/*`). Tolerant JSON parser handles cargo-mutants v25–v27 schema drift via optional fields + polymorphic `scenario` (string for baseline, `{"Mutant": {...}}` for mutants). 10 new tests: 6 unit tests on the parser + 4 integration tests driving the CLI against fixture outcomes.json files (tests don't require `cargo-mutants` to be installed on CI). Hidden `--from-outcomes` flag enables fixture-driven testing.
+
 ## [1.0.4] - 2026-04-19
 
 Three bugs caught during the self-dogfood guide's extended run on real repos. All three now have regression tests and default-rule updates.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,6 +1832,7 @@ dependencies = [
  "opentelemetry-proto",
  "predicates",
  "reqwest",
+ "serde",
  "serde_json",
  "sha2",
  "specere-core",

--- a/crates/specere/Cargo.toml
+++ b/crates/specere/Cargo.toml
@@ -26,6 +26,7 @@ specere-markers.workspace = true
 specere-units.workspace = true
 specere-telemetry.workspace = true
 specere-filter.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 fs2.workspace = true
 

--- a/crates/specere/src/evaluate.rs
+++ b/crates/specere/src/evaluate.rs
@@ -1,0 +1,443 @@
+//! `specere evaluate <kind>` — run external evaluators and emit their
+//! results as evidence events in `.specere/events.jsonl`.
+//!
+//! FR-EQ-001: mutation testing via `cargo-mutants`. The evaluator is
+//! **advisory** — a low kill rate is an evidence event, not an error.
+//! The filter's sensor-calibration formula (FR-EQ-002) later turns the
+//! aggregated kill rate into per-spec `α_sat` / `α_vio` adjustments.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{anyhow, Context, Result};
+use serde::Deserialize;
+
+/// One entry in `mutants.out/outcomes.json` — cargo-mutants v25–v27+.
+///
+/// The actual schema is tolerant-friendly: the baseline has
+/// `{"scenario": "Baseline", "summary": "Success", ...}` (scenario is a
+/// plain string), and each mutant has
+/// `{"scenario": {"Mutant": {...}}, "summary": "CaughtMutant|MissedMutant|...", ...}`
+/// (scenario is a tagged object with a single `Mutant` key). `serde_json::Value`
+/// absorbs the polymorphism; `merged_mutant()` pulls out the descriptor
+/// when present. See `crates/specere/tests/issue_070_evaluate_mutations.rs`
+/// for fixture snapshots of both shapes.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MutationOutcome {
+    #[serde(default)]
+    pub scenario: Option<serde_json::Value>,
+    #[serde(default)]
+    pub summary: Option<String>,
+}
+
+/// Mutant descriptor pulled from `scenario.Mutant` when the scenario is a
+/// mutant (not the baseline). All fields optional — cargo-mutants schema
+/// drift across versions is handled one field at a time.
+#[derive(Debug, Clone, Default)]
+pub struct MutantDescriptor {
+    pub file: Option<String>,
+    pub function_name: Option<String>,
+    pub line: Option<u64>,
+    pub genre: Option<String>,
+    pub description: Option<String>,
+}
+
+impl MutationOutcome {
+    /// Extract the `scenario.Mutant` descriptor if this outcome is for a
+    /// mutant (vs the baseline). Returns `None` for baseline / unparseable
+    /// scenarios.
+    pub fn merged_mutant(&self) -> Option<MutantDescriptor> {
+        let scenario = self.scenario.as_ref()?;
+        let mutant = scenario.get("Mutant")?.as_object()?;
+        let file = mutant
+            .get("file")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let function_name = mutant
+            .get("function")
+            .and_then(|f| f.get("function_name"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let line = mutant
+            .get("span")
+            .and_then(|s| s.get("start"))
+            .and_then(|st| st.get("line"))
+            .and_then(|l| l.as_u64());
+        let genre = mutant
+            .get("genre")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        // `name` is cargo-mutants' human-readable summary of the mutation.
+        let description = mutant
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        Some(MutantDescriptor {
+            file,
+            function_name,
+            line,
+            genre,
+            description,
+        })
+    }
+}
+
+/// The whole `outcomes.json` — current layout is `{"outcomes": [...]}`.
+/// Older/alt layouts (bare array) are also accepted for forward-compat.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum OutcomesFile {
+    Wrapped { outcomes: Vec<MutationOutcome> },
+    BareList(Vec<MutationOutcome>),
+}
+
+impl OutcomesFile {
+    pub fn into_outcomes(self) -> Vec<MutationOutcome> {
+        match self {
+            Self::Wrapped { outcomes } => outcomes,
+            Self::BareList(v) => v,
+        }
+    }
+}
+
+/// Normalised outcome class. We collapse cargo-mutants' string labels to
+/// the four-state signal the filter consumes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutcomeClass {
+    /// Mutant was detected by a failing test — good. Contributes to kill rate.
+    Caught,
+    /// Mutant passed all tests — bad. The test suite can't discriminate.
+    Missed,
+    /// Mutant caused a hang beyond the per-mutant timeout.
+    Timeout,
+    /// Mutant failed to build — excluded from the kill-rate denominator.
+    Unviable,
+}
+
+impl OutcomeClass {
+    /// Map cargo-mutants' summary strings to our normalised classification.
+    /// v27 emits `"CaughtMutant"`/`"MissedMutant"`/`"Success"` (baseline) /
+    /// `"Timeout"` / `"Unviable"`. Earlier versions used `"Caught"`/`"Missed"`.
+    /// We accept both. Baseline's `"Success"` maps to None (skip — it's the
+    /// control run, not a mutant).
+    pub fn from_summary(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "caughtmutant" | "caught" => Some(Self::Caught),
+            "missedmutant" | "missed" | "failure" => Some(Self::Missed),
+            "timeout" => Some(Self::Timeout),
+            "unviable" => Some(Self::Unviable),
+            // "success" = baseline run (no mutation applied). Not a mutant
+            // outcome, so skip. Any other unknown summary is also skipped.
+            _ => None,
+        }
+    }
+    pub fn as_attr(self) -> &'static str {
+        match self {
+            Self::Caught => "caught",
+            Self::Missed => "missed",
+            Self::Timeout => "timeout",
+            Self::Unviable => "unviable",
+        }
+    }
+}
+
+/// Parse `outcomes.json` from a `cargo-mutants` run.
+pub fn parse_outcomes_json(raw: &str) -> Result<Vec<MutationOutcome>> {
+    let file: OutcomesFile =
+        serde_json::from_str(raw).context("parse cargo-mutants outcomes.json")?;
+    Ok(file.into_outcomes())
+}
+
+/// Attribute each outcome to at most one spec by intersecting its source
+/// path with the `[specs]` support sets in sensor-map. Directory-boundary
+/// semantics match `calibrate::compute_report` (fix in v1.0.1).
+pub fn attribute_to_spec<'a>(
+    source_path: &str,
+    specs: &'a [specere_filter::hmm::SpecDescriptor],
+) -> Option<&'a str> {
+    for spec in specs {
+        for sup in &spec.support {
+            let bare = sup.trim_end_matches('/');
+            let dir = format!("{bare}/");
+            if source_path == bare || source_path.starts_with(dir.as_str()) {
+                return Some(&spec.id);
+            }
+        }
+    }
+    None
+}
+
+/// CLI entry — `specere evaluate mutations`. Run `cargo-mutants` (or skip
+/// and parse a pre-existing outcomes.json when `from_outcomes` is set, for
+/// tests), then emit one `mutation_result` event per parsed outcome.
+pub fn run_mutations(
+    ctx: &specere_core::Ctx,
+    sensor_map: Option<PathBuf>,
+    scope: Option<String>,
+    in_diff: Option<String>,
+    jobs: usize,
+    from_outcomes: Option<PathBuf>,
+) -> Result<()> {
+    let sensor_map_path = sensor_map.unwrap_or_else(|| ctx.repo().join(".specere/sensor-map.toml"));
+    let specs = specere_filter::load_specs(&sensor_map_path)?;
+
+    // Scope filter — if --scope FR-001, only mutate files in that spec's support.
+    let scoped_files: Option<Vec<String>> = scope.as_deref().map(|fr| {
+        specs
+            .iter()
+            .find(|s| s.id == fr)
+            .map(|s| s.support.clone())
+            .unwrap_or_default()
+    });
+    if scope.is_some() && scoped_files.as_ref().is_some_and(|v| v.is_empty()) {
+        return Err(anyhow!(
+            "--scope FR-ID {:?} not found in [specs] of {}",
+            scope,
+            sensor_map_path.display()
+        ));
+    }
+
+    let outcomes_path = match &from_outcomes {
+        Some(p) => p.clone(),
+        None => {
+            let out_dir = ctx.repo().join(".specere/mutants.out");
+            run_cargo_mutants(
+                ctx.repo(),
+                &out_dir,
+                scoped_files.as_deref(),
+                in_diff.as_deref(),
+                jobs,
+            )?;
+            out_dir.join("outcomes.json")
+        }
+    };
+
+    let raw = std::fs::read_to_string(&outcomes_path)
+        .with_context(|| format!("read {}", outcomes_path.display()))?;
+    let outcomes = parse_outcomes_json(&raw)?;
+
+    let mut emitted = 0usize;
+    let mut unattributed = 0usize;
+    for o in &outcomes {
+        let Some(summary) = o.summary.as_deref().and_then(OutcomeClass::from_summary) else {
+            // Baseline scenario, or unknown summary — skip.
+            continue;
+        };
+        let mutant = o.merged_mutant().unwrap_or_default();
+        let source = mutant.file.clone();
+        let spec_id = source
+            .as_deref()
+            .and_then(|p| attribute_to_spec(p, &specs))
+            .map(String::from);
+
+        if spec_id.is_none() && summary != OutcomeClass::Unviable {
+            unattributed += 1;
+        }
+
+        let mut attrs = std::collections::BTreeMap::new();
+        attrs.insert("event_kind".to_string(), "mutation_result".to_string());
+        if let Some(sid) = &spec_id {
+            attrs.insert("spec_id".to_string(), sid.clone());
+        }
+        attrs.insert("outcome".to_string(), summary.as_attr().to_string());
+        if let Some(s) = source.as_deref() {
+            attrs.insert("file".to_string(), s.to_string());
+        }
+        if let Some(fn_name) = &mutant.function_name {
+            attrs.insert("function".to_string(), fn_name.clone());
+        }
+        if let Some(line) = mutant.line {
+            attrs.insert("line".to_string(), line.to_string());
+        }
+        if let Some(g) = &mutant.genre {
+            attrs.insert("operator".to_string(), g.clone());
+        }
+
+        let event = specere_telemetry::Event {
+            ts: specere_telemetry::event_store::now_rfc3339(),
+            source: "cargo-mutants".into(),
+            signal: "traces".into(),
+            name: mutant.description.clone(),
+            feature_dir: None,
+            attrs,
+        };
+        specere_telemetry::record(ctx, event)?;
+        emitted += 1;
+    }
+
+    println!(
+        "specere evaluate mutations: {emitted} mutation event(s) emitted \
+         ({unattributed} unattributed to any [specs] entry)"
+    );
+    Ok(())
+}
+
+fn run_cargo_mutants(
+    repo: &Path,
+    out_dir: &Path,
+    scoped_files: Option<&[String]>,
+    in_diff: Option<&str>,
+    jobs: usize,
+) -> Result<()> {
+    // cargo-mutants is a cargo subcommand, invoked as `cargo mutants`.
+    let mut cmd = Command::new("cargo");
+    cmd.current_dir(repo)
+        .args(["mutants", "--json", "--output"])
+        .arg(out_dir)
+        .arg(format!("--jobs={jobs}"));
+    if let Some(files) = scoped_files {
+        for f in files {
+            cmd.arg("--file").arg(f);
+        }
+    }
+    if let Some(d) = in_diff {
+        cmd.arg("--in-diff").arg(d);
+    }
+    let out = cmd.output().with_context(|| {
+        "spawn `cargo mutants` — is it installed? `cargo install cargo-mutants`"
+    })?;
+    // cargo-mutants exits non-zero when mutants are missed (by design).
+    // We don't propagate that as an error — the missed mutants are the
+    // point of the evidence signal.
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        // A missing binary error is worth surfacing; a "some mutants
+        // missed" exit is not. Heuristic: if stderr mentions "error: ..."
+        // AND outcomes.json doesn't exist afterwards, it's a real error.
+        if !out_dir.join("outcomes.json").exists() {
+            return Err(anyhow!(
+                "cargo-mutants failed without producing outcomes.json.\nstdout: {stdout}\nstderr: {stderr}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use specere_filter::hmm::SpecDescriptor;
+
+    fn spec(id: &str, support: &[&str]) -> SpecDescriptor {
+        SpecDescriptor {
+            id: id.into(),
+            support: support.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn parse_v27_wrapped_layout_with_baseline_and_mutant() {
+        // Matches what `cargo mutants --json` v27 actually emits: a baseline
+        // entry with `scenario: "Baseline"` (string) and mutant entries with
+        // `scenario: {"Mutant": {...}}` (tagged object).
+        let raw = r#"{
+            "outcomes": [
+                {"scenario": "Baseline", "summary": "Success"},
+                {"scenario": {"Mutant": {
+                    "name": "replace add -> i32 with 0",
+                    "file": "src/lib.rs",
+                    "function": {"function_name": "add"},
+                    "span": {"start": {"line": 1, "column": 37}},
+                    "genre": "FnValue"
+                }}, "summary": "CaughtMutant"},
+                {"scenario": {"Mutant": {
+                    "name": "replace > with >= in is_positive",
+                    "file": "src/lib.rs",
+                    "function": {"function_name": "is_positive"},
+                    "span": {"start": {"line": 2, "column": 40}},
+                    "genre": "BinaryOp"
+                }}, "summary": "MissedMutant"}
+            ]
+        }"#;
+        let out = parse_outcomes_json(raw).unwrap();
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].summary.as_deref(), Some("Success"));
+        assert!(out[0].merged_mutant().is_none(), "baseline has no Mutant");
+
+        let m1 = out[1].merged_mutant().unwrap();
+        assert_eq!(m1.file.as_deref(), Some("src/lib.rs"));
+        assert_eq!(m1.function_name.as_deref(), Some("add"));
+        assert_eq!(m1.line, Some(1));
+        assert_eq!(m1.genre.as_deref(), Some("FnValue"));
+
+        let m2 = out[2].merged_mutant().unwrap();
+        assert_eq!(m2.function_name.as_deref(), Some("is_positive"));
+        assert_eq!(m2.line, Some(2));
+    }
+
+    #[test]
+    fn parse_handles_bare_list_layout() {
+        let raw = r#"[{"scenario": {"Mutant": {"file":"src/b.rs","span":{"start":{"line":7}}}}, "summary":"MissedMutant"}]"#;
+        let out = parse_outcomes_json(raw).unwrap();
+        assert_eq!(out[0].summary.as_deref(), Some("MissedMutant"));
+        let m = out[0].merged_mutant().unwrap();
+        assert_eq!(m.file.as_deref(), Some("src/b.rs"));
+        assert_eq!(m.line, Some(7));
+    }
+
+    #[test]
+    fn outcome_class_maps_v27_and_case_insensitive() {
+        assert_eq!(
+            OutcomeClass::from_summary("CaughtMutant"),
+            Some(OutcomeClass::Caught)
+        );
+        assert_eq!(
+            OutcomeClass::from_summary("MissedMutant"),
+            Some(OutcomeClass::Missed)
+        );
+        assert_eq!(
+            OutcomeClass::from_summary("Caught"),
+            Some(OutcomeClass::Caught)
+        );
+        assert_eq!(
+            OutcomeClass::from_summary("missed"),
+            Some(OutcomeClass::Missed)
+        );
+        assert_eq!(
+            OutcomeClass::from_summary("TIMEOUT"),
+            Some(OutcomeClass::Timeout)
+        );
+        assert_eq!(
+            OutcomeClass::from_summary("Unviable"),
+            Some(OutcomeClass::Unviable)
+        );
+        // Baseline's "Success" is intentionally None — baseline is not a mutant.
+        assert_eq!(OutcomeClass::from_summary("Success"), None);
+        assert_eq!(OutcomeClass::from_summary("unknown"), None);
+    }
+
+    #[test]
+    fn attribute_directory_match_is_boundary_safe() {
+        // Regression anchor from v1.0.1 — `src/auth` must NOT match
+        // `src/auth_helpers/x.rs`.
+        let specs = vec![
+            spec("auth", &["src/auth/"]),
+            spec("helpers", &["src/auth_helpers/"]),
+        ];
+        assert_eq!(attribute_to_spec("src/auth/login.rs", &specs), Some("auth"));
+        assert_eq!(
+            attribute_to_spec("src/auth_helpers/h.rs", &specs),
+            Some("helpers")
+        );
+        assert_eq!(attribute_to_spec("src/unrelated.rs", &specs), None);
+    }
+
+    #[test]
+    fn attribute_exact_file_match_works() {
+        let specs = vec![spec("main", &["src/main.rs"])];
+        assert_eq!(attribute_to_spec("src/main.rs", &specs), Some("main"));
+        // Sibling file with matching prefix must NOT match.
+        assert_eq!(attribute_to_spec("src/mainframe.rs", &specs), None);
+    }
+
+    #[test]
+    fn parse_tolerates_missing_scenario() {
+        let raw = r#"[{"summary":"CaughtMutant"}]"#;
+        let out = parse_outcomes_json(raw).unwrap();
+        assert_eq!(out.len(), 1);
+        // No scenario/Mutant — merged_mutant returns None; consumers treat
+        // as unattributed.
+        assert!(out[0].merged_mutant().is_none());
+    }
+}

--- a/crates/specere/src/main.rs
+++ b/crates/specere/src/main.rs
@@ -8,6 +8,8 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
+mod evaluate;
+
 /// SpecERE — Spec Entropy Regulation Engine.
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -108,6 +110,38 @@ enum Command {
     Calibrate {
         #[command(subcommand)]
         kind: CalibrateKind,
+    },
+    /// Run external evaluators (mutation testing, property checkers) and
+    /// emit the results as evidence events. FR-EQ-001..005.
+    Evaluate {
+        #[command(subcommand)]
+        kind: EvaluateKind,
+    },
+}
+
+#[derive(Subcommand)]
+enum EvaluateKind {
+    /// Run `cargo-mutants` and emit one `mutation_result` event per mutant
+    /// into `.specere/events.jsonl`. Events carry `spec_id` attributed via
+    /// sensor-map support-set intersection. Advisory — a low kill rate is
+    /// recorded, not an error. FR-EQ-001.
+    Mutations {
+        /// Override the sensor-map path (default: `.specere/sensor-map.toml`).
+        #[arg(long)]
+        sensor_map: Option<PathBuf>,
+        /// Restrict mutation to files supporting this FR only.
+        #[arg(long, value_name = "FR-ID")]
+        scope: Option<String>,
+        /// Pass through to `cargo-mutants --in-diff <REF>` for PR-scoped runs.
+        #[arg(long)]
+        in_diff: Option<String>,
+        /// Parallelism. Forwarded to `cargo-mutants --jobs N`.
+        #[arg(long, default_value_t = 1)]
+        jobs: usize,
+        /// Test-only — parse this existing `outcomes.json` instead of running
+        /// `cargo-mutants`. The CLI otherwise always invokes the tool fresh.
+        #[arg(long, value_name = "PATH", hide = true)]
+        from_outcomes: Option<PathBuf>,
     },
 }
 
@@ -299,6 +333,15 @@ fn main() -> Result<()> {
                 max_commits,
                 min_commits,
             } => run_calibrate_from_git(&ctx, sensor_map, max_commits, min_commits),
+        },
+        Command::Evaluate { kind } => match kind {
+            EvaluateKind::Mutations {
+                sensor_map,
+                scope,
+                in_diff,
+                jobs,
+                from_outcomes,
+            } => evaluate::run_mutations(&ctx, sensor_map, scope, in_diff, jobs, from_outcomes),
         },
     };
 

--- a/crates/specere/tests/fr_eq_001_evaluate_mutations.rs
+++ b/crates/specere/tests/fr_eq_001_evaluate_mutations.rs
@@ -1,0 +1,196 @@
+//! FR-EQ-001 — `specere evaluate mutations` end-to-end.
+//!
+//! Strategy: use the hidden `--from-outcomes <path>` flag to skip the
+//! actual `cargo mutants` invocation and point the CLI at a pre-built
+//! fixture `outcomes.json`. This makes the test independent of whether
+//! `cargo-mutants` is installed on the runner.
+
+mod common;
+
+use common::TempRepo;
+
+fn seed_sensor_map(repo: &TempRepo) {
+    repo.write(
+        ".specere/sensor-map.toml",
+        r#"
+schema_version = 1
+
+[specs]
+"auth"     = { support = ["src/auth/"] }
+"billing"  = { support = ["src/billing/"] }
+
+[channels]
+"#,
+    );
+}
+
+/// Fixture mimicking `cargo mutants --json` v27 output: one baseline + 4
+/// mutants. 2 caught + 2 missed across two specs.
+const FIXTURE_OUTCOMES: &str = r#"{
+  "outcomes": [
+    {"scenario": "Baseline", "summary": "Success"},
+    {"scenario": {"Mutant": {
+        "name": "replace auth_check -> bool with true",
+        "file": "src/auth/mod.rs",
+        "function": {"function_name": "auth_check"},
+        "span": {"start": {"line": 12, "column": 1}},
+        "genre": "FnValue"
+    }}, "summary": "CaughtMutant"},
+    {"scenario": {"Mutant": {
+        "name": "replace auth_token -> String with String::new()",
+        "file": "src/auth/token.rs",
+        "function": {"function_name": "auth_token"},
+        "span": {"start": {"line": 7, "column": 1}},
+        "genre": "FnValue"
+    }}, "summary": "MissedMutant"},
+    {"scenario": {"Mutant": {
+        "name": "replace >= with > in charge",
+        "file": "src/billing/charge.rs",
+        "function": {"function_name": "charge"},
+        "span": {"start": {"line": 3, "column": 14}},
+        "genre": "BinaryOp"
+    }}, "summary": "CaughtMutant"},
+    {"scenario": {"Mutant": {
+        "name": "replace refund -> bool with false",
+        "file": "src/billing/refund.rs",
+        "function": {"function_name": "refund"},
+        "span": {"start": {"line": 4, "column": 1}},
+        "genre": "FnValue"
+    }}, "summary": "Unviable"},
+    {"scenario": {"Mutant": {
+        "name": "mutant in unrelated file",
+        "file": "src/unrelated/helper.rs",
+        "function": {"function_name": "helper"},
+        "span": {"start": {"line": 1, "column": 1}},
+        "genre": "FnValue"
+    }}, "summary": "MissedMutant"}
+  ]
+}"#;
+
+#[test]
+fn emits_one_event_per_mutant_with_spec_attribution() {
+    let repo = TempRepo::new();
+    seed_sensor_map(&repo);
+    let fixture = repo.abs(".specere/fixtures/outcomes.json");
+    std::fs::create_dir_all(fixture.parent().unwrap()).unwrap();
+    std::fs::write(&fixture, FIXTURE_OUTCOMES).unwrap();
+
+    let out = repo
+        .run_specere(&["evaluate", "mutations", "--from-outcomes"])
+        .arg(&fixture)
+        .output()
+        .expect("spawn");
+    assert!(
+        out.status.success(),
+        "evaluate mutations failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // 5 mutants (baseline skipped) → 5 mutation_result events; 1 is
+    // "unrelated" (unattributed), 4 are spec-attributed.
+    let raw = std::fs::read_to_string(repo.abs(".specere/events.jsonl")).unwrap();
+    let lines: Vec<&str> = raw.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert_eq!(
+        lines.len(),
+        5,
+        "expected 5 mutation events (1 per mutant, baseline skipped); got:\n{raw}"
+    );
+
+    let mut auth_caught = 0;
+    let mut auth_missed = 0;
+    let mut billing_caught = 0;
+    let mut billing_unviable = 0;
+    let mut unattributed_missed = 0;
+    for line in &lines {
+        let v: serde_json::Value = serde_json::from_str(line).unwrap();
+        let attrs = v["attrs"].as_object().unwrap();
+        assert_eq!(
+            attrs.get("event_kind").and_then(|v| v.as_str()),
+            Some("mutation_result"),
+            "event_kind should be mutation_result"
+        );
+        let spec = attrs.get("spec_id").and_then(|v| v.as_str());
+        let outcome = attrs.get("outcome").and_then(|v| v.as_str()).unwrap();
+        match (spec, outcome) {
+            (Some("auth"), "caught") => auth_caught += 1,
+            (Some("auth"), "missed") => auth_missed += 1,
+            (Some("billing"), "caught") => billing_caught += 1,
+            (Some("billing"), "unviable") => billing_unviable += 1,
+            (None, "missed") => unattributed_missed += 1,
+            other => panic!("unexpected event: {other:?} in {line}"),
+        }
+    }
+    assert_eq!(auth_caught, 1);
+    assert_eq!(auth_missed, 1);
+    assert_eq!(billing_caught, 1);
+    assert_eq!(billing_unviable, 1);
+    assert_eq!(unattributed_missed, 1);
+}
+
+#[test]
+fn scope_flag_requires_fr_id_to_exist_in_specs() {
+    let repo = TempRepo::new();
+    seed_sensor_map(&repo);
+    let fixture = repo.abs(".specere/fixtures/outcomes.json");
+    std::fs::create_dir_all(fixture.parent().unwrap()).unwrap();
+    std::fs::write(&fixture, FIXTURE_OUTCOMES).unwrap();
+
+    let out = repo
+        .run_specere(&["evaluate", "mutations", "--scope", "FR-NONEXISTENT"])
+        .output()
+        .expect("spawn");
+    assert!(!out.status.success(), "unknown --scope should error");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("FR-NONEXISTENT") && stderr.contains("[specs]"),
+        "error should name the missing FR + [specs]:\n{stderr}"
+    );
+}
+
+#[test]
+fn reports_unattributed_mutants_in_summary() {
+    let repo = TempRepo::new();
+    seed_sensor_map(&repo);
+    let fixture = repo.abs(".specere/fixtures/outcomes.json");
+    std::fs::create_dir_all(fixture.parent().unwrap()).unwrap();
+    std::fs::write(&fixture, FIXTURE_OUTCOMES).unwrap();
+
+    let out = repo
+        .run_specere(&["evaluate", "mutations", "--from-outcomes"])
+        .arg(&fixture)
+        .output()
+        .expect("spawn");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("5 mutation event") && stdout.contains("1 unattributed"),
+        "summary should report counts and unattributed:\n{stdout}"
+    );
+}
+
+#[test]
+fn errors_cleanly_when_cargo_mutants_missing_and_no_fixture() {
+    // Without `--from-outcomes` we'd try to invoke `cargo mutants`. In a
+    // TempRepo's tempdir (no Cargo.toml, no cargo workspace), the command
+    // must fail with a clear error rather than panic. Some environments
+    // DO have cargo-mutants installed so this just verifies "doesn't
+    // panic and exits non-zero." If the subcommand happens to run
+    // successfully against a non-Rust dir, we still expect a clean error
+    // because outcomes.json won't exist afterwards.
+    let repo = TempRepo::new();
+    seed_sensor_map(&repo);
+    let out = repo
+        .run_specere(&["evaluate", "mutations"])
+        .output()
+        .expect("spawn");
+    // Allow either exit — the point is no panic, and some friendly text.
+    let all = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !all.contains("panicked at"),
+        "specere should not panic on cargo-mutants failure:\n{all}"
+    );
+}


### PR DESCRIPTION
First implementation PR for the evidence-quality upgrade. Closes #70 (FR-EQ-001), advances parent tracker #69 (v1.0.5 slice).

Plan reference: \`docs/evidence-quality-plan.md §1\`.

## What ships

\`specere evaluate mutations\` — a new subcommand that wraps \`cargo mutants --json\` with per-spec scoping and emits one \`mutation_result\` event per mutant into the existing event-store pipeline. No filter changes yet; the events sit in the store waiting for FR-EQ-002 (sensor calibration) to consume them.

### Flags

- \`--scope FR-ID\` — mutate only files listed in that spec's \`support\` set.
- \`--in-diff <REF>\` — PR-scoped run (forwards to \`cargo-mutants --in-diff\`).
- \`--jobs N\` — parallelism.
- \`--sensor-map PATH\` — override default sensor-map path.
- \`--from-outcomes PATH\` (hidden) — skip \`cargo-mutants\` invocation, parse a pre-existing \`outcomes.json\`. This is how the integration tests avoid needing \`cargo-mutants\` on CI runners.

### Parser tolerance

cargo-mutants' JSON schema has drifted across v24 → v27. The parser uses \`serde_json::Value\` for polymorphic fields (notably \`scenario\` which is either the string \`\"Baseline\"\` OR an object \`{\"Mutant\": {...}}\`) and treats every descriptor field as optional. Summary strings \`CaughtMutant\`/\`MissedMutant\` (v27) and \`Caught\`/\`Missed\` (earlier) both map to the normalised \`OutcomeClass\` enum.

### Spec attribution

Same directory-boundary logic from the v1.0.1 calibrate fix — a mutant in \`src/auth/login.rs\` matches support \`src/auth\` or \`src/auth/\` but NOT support \`src/aut\`. Regression-locked via \`attribute_directory_match_is_boundary_safe\` + \`attribute_exact_file_match_works\`.

## Tests

| Kind | Count | Coverage |
|---|---|---|
| Unit (parser) | 6 | v27 wrapped layout, bare-list fallback, case-insensitive summaries, boundary-safe attribution, exact-file match, missing-field tolerance |
| Integration (CLI) | 4 | End-to-end event emission + attribution, \`--scope\` error path, unattributed-count summary, no-panic when cargo-mutants absent |

**Total workspace: 198 (188 + 10).** All CI gates green on the prior release.

## Not in this PR

- FR-EQ-002 (sensor calibration formula) — next.
- FR-EQ-005 (filter-run integration that consumes these events) — after 002.
- User-facing docs for the verb — will land with FR-EQ-005 once the whole loop is user-visible.

## Review focus

- Parser tolerance: is the \`#[serde(untagged)]\` \`OutcomesFile\` enum plus the \`merged_mutant()\` helper the right level of forward-compat for cargo-mutants schema drift?
- Event attr naming: \`operator\` (cargo-mutants calls this \`genre\`) — renamed to match what OTel GenAI semconv would likely call it.
- The \`--from-outcomes\` hidden flag — legitimate test seam, or hack that should go away before release?