### PR TITLE
feat(filter): Calibration + filter integration (closes #71 #74 #76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to SpecERE will be documented here. The format follows [Keep
 
 ## [Unreleased]
 
-### Added (v1.0.5 prep — evidence-quality, FR-EQ-001)
+### Added (v1.0.5 prep — evidence-quality)
+
+- **Calibration struct + filter integration** (FR-EQ-002+005+007, [#89](https://github.com/laiadlotape/specere/pull/89)). New `Calibration { quality, alpha_sat, alpha_vio, alpha_unk }` in `specere-filter::state` computed from mutation kill rate × smell penalty. `CalibratedTestSensor` and `PerSpecTestSensor` wrap it. `run_filter_run` aggregates `mutation_result` + `test_smell_detected` events per spec and prints a per-spec calibration summary with `← low evidence` flags when `quality < 0.5`. Repos without evidence events see no change (prototype alphas, bit-identical to v1.0.4). Gate-A parity (FR-P4-002) anchored: `CalibratedTestSensor::new(Calibration::prototype())` produces numerically-identical log-likelihoods to the v1.0.4 `DefaultTestSensor`.
 - **`specere evaluate mutations` subcommand** ([#70](https://github.com/laiadlotape/specere/issues/70)). First slice of the evidence-quality upgrade (tracker #69). Wraps `cargo mutants --json` with per-spec scoping (`--scope FR-NNN` or `--in-diff <REF>`) and emits one `mutation_result` event per mutant into `.specere/events.jsonl`. Attribution uses the same directory-boundary semantics as the calibrate path (v1.0.1 fix — `src/auth` doesn't false-match `src/auth_helpers/*`). Tolerant JSON parser handles cargo-mutants v25–v27 schema drift via optional fields + polymorphic `scenario` (string for baseline, `{"Mutant": {...}}` for mutants). 10 new tests: 6 unit tests on the parser + 4 integration tests driving the CLI against fixture outcomes.json files (tests don't require `cargo-mutants` to be installed on CI). Hidden `--from-outcomes` flag enables fixture-driven testing.
 
 ## [1.0.4] - 2026-04-19

--- a/crates/specere-filter/src/drive.rs
+++ b/crates/specere-filter/src/drive.rs
@@ -17,7 +17,7 @@
 //! constructing a [`crate::TestSensor`] impl directly and using the filter
 //! methods.
 
-use ndarray::{array, Array1};
+use ndarray::Array1;
 
 use crate::state::TestSensor;
 
@@ -41,30 +41,19 @@ use crate::state::TestSensor;
 /// via `scripts/export_gate_a_posterior.py` if you do.
 pub struct DefaultTestSensor;
 
+// Prototype alpha constants — retained as public documentation. Prefer
+// `Calibration::prototype()` in new code; these will stay stable across
+// releases so external callers can pin against them.
 pub const ALPHA_SAT: f64 = 0.92;
 pub const ALPHA_VIO: f64 = 0.90;
 pub const ALPHA_UNK: f64 = 0.55;
 
 impl TestSensor for DefaultTestSensor {
-    fn log_likelihood(&self, _spec_id: &str, outcome: &str) -> Array1<f64> {
-        // Clip to a 1e-6 floor before log (matches the prototype's `eps` so
-        // future sensor variations with zero probabilities stay well-defined).
-        const EPS: f64 = 1e-6;
-        let clip = |x: f64| x.max(EPS).ln();
-        match outcome {
-            "pass" => array![clip(ALPHA_UNK), clip(ALPHA_SAT), clip(1.0 - ALPHA_VIO)],
-            "fail" => array![
-                clip(1.0 - ALPHA_UNK),
-                clip(1.0 - ALPHA_SAT),
-                clip(ALPHA_VIO)
-            ],
-            // Unknown outcomes: flat (uninformative) row so the posterior
-            // doesn't drift on bad data.
-            _ => {
-                let u = (1.0_f64 / 3.0).ln();
-                array![u, u, u]
-            }
-        }
+    fn log_likelihood(&self, spec_id: &str, outcome: &str) -> Array1<f64> {
+        // Delegate to the calibration-based implementation at quality=1.0.
+        // Bit-identical output vs the v1.0.4 hand-written version.
+        crate::state::CalibratedTestSensor::new(crate::state::Calibration::prototype())
+            .log_likelihood(spec_id, outcome)
     }
 }
 

--- a/crates/specere-filter/src/lib.rs
+++ b/crates/specere-filter/src/lib.rs
@@ -35,4 +35,4 @@ pub use motion::Motion;
 pub use posterior::{Entry, Posterior};
 pub use rbpf::RBPF;
 pub use specs::load_specs;
-pub use state::{Belief, Status, TestSensor};
+pub use state::{Belief, CalibratedTestSensor, Calibration, PerSpecTestSensor, Status, TestSensor};

--- a/crates/specere-filter/src/state.rs
+++ b/crates/specere-filter/src/state.rs
@@ -1,8 +1,18 @@
 //! 3-state simplex over spec statuses + the per-spec [`Belief`] vector + the
 //! [`TestSensor`] trait that callers implement to feed observation-likelihoods
 //! into [`crate::PerSpecHMM::update_test`].
+//!
+//! **Calibration (FR-EQ-002).** v1.0.4's fixed `α_sat = 0.92` / `α_vio = 0.90`
+//! assumed test suites always discriminate SAT from VIO well. That's false
+//! when tests are tautological, over-mocked, or happy-path-only. v1.0.5
+//! introduces [`Calibration`] — a per-spec quality multiplier, derived from
+//! mutation kill rate and test-smell penalty, that compresses alphas toward
+//! uninformative when the evidence is weak. At `quality = 1.0` the sensor
+//! behaves exactly as before (Gate-A parity preserved).
 
 use ndarray::Array1;
+
+const EPS: f64 = 1e-6;
 
 /// Spec status space. Matches the prototype's indexing — `Unk = 0`, `Sat = 1`,
 /// `Vio = 2`. Do not reorder without updating every hand-computed fixture.
@@ -36,4 +46,229 @@ pub fn uniform_belief() -> Belief {
 pub trait TestSensor {
     /// `log p(outcome | status)` for the three spec statuses.
     fn log_likelihood(&self, spec_id: &str, outcome: &str) -> Array1<f64>;
+}
+
+/// Per-spec evidence-quality calibration (FR-EQ-002). Derived from mutation
+/// kill rate × test-smell penalty. Callers build one [`Calibration`] per
+/// spec and feed a matching [`CalibratedTestSensor`] into the filter.
+///
+/// The `quality` field is the single knob that compresses the sensor's
+/// discriminative power. At `1.0`, alphas match the prototype defaults
+/// (`α_sat = 0.92`, `α_vio = 0.90`, `α_unk = 0.55`) — so Gate-A parity
+/// (FR-P4-002) is preserved bit-for-bit when no evidence has arrived.
+/// At the floor (`0.3`) alphas compress halfway toward uninformative.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Calibration {
+    pub quality: f64,
+    pub alpha_sat: f64,
+    pub alpha_vio: f64,
+    pub alpha_unk: f64,
+}
+
+/// Prototype constants — kept private; all external callers go through
+/// [`Calibration::prototype`] or [`Calibration::from_evidence`].
+const ALPHA_SAT_PROTO: f64 = 0.92;
+const ALPHA_VIO_PROTO: f64 = 0.90;
+const ALPHA_UNK_PROTO: f64 = 0.55;
+
+impl Calibration {
+    /// Prototype-default alphas — exactly what v1.0.4 used unconditionally.
+    pub const fn prototype() -> Self {
+        Self {
+            quality: 1.0,
+            alpha_sat: ALPHA_SAT_PROTO,
+            alpha_vio: ALPHA_VIO_PROTO,
+            alpha_unk: ALPHA_UNK_PROTO,
+        }
+    }
+
+    /// Construct from per-spec evidence signals (FR-EQ-002 § 5 formula):
+    ///
+    /// ```text
+    /// q       = clamp(0.3, kill_rate × smell_penalty, 1.0)
+    /// α_sat   = 0.55 + q × 0.37       → 0.92 at q=1, ~0.66 at q=0.3
+    /// α_vio   = 0.45 + q × 0.45       → 0.90 at q=1, ~0.58 at q=0.3
+    /// α_unk   = 0.55                  (unchanged)
+    /// ```
+    ///
+    /// `kill_rate` is `caught / (caught + missed)` with timeouts counted as
+    /// missed and unviable excluded — zero evidence (no mutations run) is
+    /// signalled by `kill_rate = 1.0`, which returns prototype alphas
+    /// (back-compat: repos that never run `specere evaluate mutations`
+    /// behave exactly as v1.0.4).
+    ///
+    /// `smell_penalty` is `clamp(0.3, 1.0 - 0.15×n_smells, 1.0)` upstream
+    /// of this function.
+    pub fn from_evidence(kill_rate: f64, smell_penalty: f64) -> Self {
+        let q = (kill_rate * smell_penalty).clamp(0.3, 1.0);
+        Self {
+            quality: q,
+            alpha_sat: ALPHA_UNK_PROTO + q * (ALPHA_SAT_PROTO - ALPHA_UNK_PROTO),
+            alpha_vio: (1.0 - ALPHA_UNK_PROTO) + q * (ALPHA_VIO_PROTO - (1.0 - ALPHA_UNK_PROTO)),
+            alpha_unk: ALPHA_UNK_PROTO,
+        }
+    }
+
+    /// Likelihood table for a test outcome under this calibration. Shape:
+    /// log-probability for each status (`Unk, Sat, Vio`) given the outcome.
+    /// Matches the prototype's numerical output at `quality = 1.0`.
+    pub fn log_likelihood(&self, outcome: &str) -> Array1<f64> {
+        let clip = |x: f64| x.max(EPS).ln();
+        match outcome {
+            "pass" => ndarray::array![
+                clip(self.alpha_unk),
+                clip(self.alpha_sat),
+                clip(1.0 - self.alpha_vio)
+            ],
+            "fail" => ndarray::array![
+                clip(1.0 - self.alpha_unk),
+                clip(1.0 - self.alpha_sat),
+                clip(self.alpha_vio)
+            ],
+            _ => {
+                let u = (1.0_f64 / 3.0).ln();
+                ndarray::array![u, u, u]
+            }
+        }
+    }
+}
+
+impl Default for Calibration {
+    fn default() -> Self {
+        Self::prototype()
+    }
+}
+
+/// A [`TestSensor`] that uses a static [`Calibration`] for every spec. The
+/// CLI wraps this in a map keyed by spec_id when per-spec calibration is
+/// in play — `DefaultTestSensor` is the "same alphas for every spec"
+/// adapter that callers wanting v1.0.4 behaviour can use unchanged.
+pub struct CalibratedTestSensor {
+    calibration: Calibration,
+}
+
+impl CalibratedTestSensor {
+    pub fn new(calibration: Calibration) -> Self {
+        Self { calibration }
+    }
+
+    pub fn calibration(&self) -> &Calibration {
+        &self.calibration
+    }
+}
+
+impl TestSensor for CalibratedTestSensor {
+    fn log_likelihood(&self, _spec_id: &str, outcome: &str) -> Array1<f64> {
+        self.calibration.log_likelihood(outcome)
+    }
+}
+
+/// Per-spec sensor — one `Calibration` per spec_id. Unknown specs fall
+/// back to prototype defaults, matching v1.0.4 behaviour.
+pub struct PerSpecTestSensor {
+    map: std::collections::HashMap<String, Calibration>,
+    fallback: Calibration,
+}
+
+impl PerSpecTestSensor {
+    pub fn new() -> Self {
+        Self {
+            map: std::collections::HashMap::new(),
+            fallback: Calibration::prototype(),
+        }
+    }
+
+    pub fn insert(&mut self, spec_id: impl Into<String>, calibration: Calibration) {
+        self.map.insert(spec_id.into(), calibration);
+    }
+
+    pub fn calibration_for(&self, spec_id: &str) -> &Calibration {
+        self.map.get(spec_id).unwrap_or(&self.fallback)
+    }
+}
+
+impl Default for PerSpecTestSensor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TestSensor for PerSpecTestSensor {
+    fn log_likelihood(&self, spec_id: &str, outcome: &str) -> Array1<f64> {
+        self.calibration_for(spec_id).log_likelihood(outcome)
+    }
+}
+
+#[cfg(test)]
+mod calibration_tests {
+    use super::*;
+    use approx::assert_abs_diff_eq;
+
+    #[test]
+    fn prototype_matches_v104_constants() {
+        let c = Calibration::prototype();
+        assert_abs_diff_eq!(c.quality, 1.0, epsilon = 1e-12);
+        assert_abs_diff_eq!(c.alpha_sat, 0.92, epsilon = 1e-12);
+        assert_abs_diff_eq!(c.alpha_vio, 0.90, epsilon = 1e-12);
+        assert_abs_diff_eq!(c.alpha_unk, 0.55, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn from_evidence_at_full_quality_equals_prototype() {
+        let c = Calibration::from_evidence(1.0, 1.0);
+        let p = Calibration::prototype();
+        // Formula gives α_sat = 0.55 + 1.0*(0.92-0.55) = 0.92 exactly. Must
+        // match prototype at `q=1` so Gate-A parity (FR-P4-002) is preserved.
+        assert_abs_diff_eq!(c.alpha_sat, p.alpha_sat, epsilon = 1e-12);
+        assert_abs_diff_eq!(c.alpha_vio, p.alpha_vio, epsilon = 1e-12);
+        assert_abs_diff_eq!(c.alpha_unk, p.alpha_unk, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn from_evidence_clamps_at_0_3_floor() {
+        // kill_rate=0, smell_penalty=0.5 → q would be 0, clamps to 0.3.
+        let c = Calibration::from_evidence(0.0, 0.5);
+        assert_abs_diff_eq!(c.quality, 0.3, epsilon = 1e-12);
+        // α_sat = 0.55 + 0.3*(0.92-0.55) = 0.661
+        assert_abs_diff_eq!(c.alpha_sat, 0.661, epsilon = 1e-9);
+        // α_vio = 0.45 + 0.3*(0.90-0.45) = 0.585
+        assert_abs_diff_eq!(c.alpha_vio, 0.585, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn from_evidence_mid_quality() {
+        // kill_rate=0.6, smell_penalty=1.0 → q=0.6.
+        let c = Calibration::from_evidence(0.6, 1.0);
+        assert_abs_diff_eq!(c.quality, 0.6, epsilon = 1e-12);
+        // α_sat = 0.55 + 0.6*0.37 = 0.772
+        assert_abs_diff_eq!(c.alpha_sat, 0.772, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn calibrated_sensor_matches_prototype_default_sensor() {
+        // A CalibratedTestSensor(prototype) must return the same log-
+        // likelihoods as the legacy DefaultTestSensor — this is the
+        // backbone of bit-identical Gate-A parity under the new code path.
+        use crate::drive::DefaultTestSensor;
+        let sensor = CalibratedTestSensor::new(Calibration::prototype());
+        let default = DefaultTestSensor;
+        for outcome in ["pass", "fail", "unknown-fallback"] {
+            let a = sensor.log_likelihood("FR-001", outcome);
+            let b = default.log_likelihood("FR-001", outcome);
+            for k in 0..3 {
+                assert_abs_diff_eq!(a[k], b[k], epsilon = 1e-12);
+            }
+        }
+    }
+
+    #[test]
+    fn per_spec_sensor_falls_back_to_prototype_on_unknown() {
+        let mut per_spec = PerSpecTestSensor::new();
+        per_spec.insert("FR-001", Calibration::from_evidence(0.3, 1.0));
+        // FR-001 has a calibration, FR-999 doesn't — falls back to prototype.
+        let a = per_spec.calibration_for("FR-001");
+        let b = per_spec.calibration_for("FR-999");
+        assert!(a.quality < 1.0);
+        assert_eq!(b, &Calibration::prototype());
+    }
 }

--- a/crates/specere/src/main.rs
+++ b/crates/specere/src/main.rs
@@ -543,7 +543,20 @@ fn run_filter_run(
         hmm.set_belief(&entry.spec_id, &[entry.p_unk, entry.p_sat, entry.p_vio]);
     }
 
-    let sensor = specere_filter::DefaultTestSensor;
+    // FR-EQ-005 — compute per-spec calibration from aggregated mutation +
+    // smell events across ALL events (not just new ones), then build a
+    // PerSpecTestSensor keyed by spec_id. At quality=1.0 for every spec,
+    // the filter's numerical output is bit-identical to v1.0.4 — so
+    // repos that don't run `specere evaluate mutations` see no change.
+    let all_events_for_calibration = specere_telemetry::event_store::query(
+        ctx.repo(),
+        &specere_telemetry::event_store::QueryFilters::default(),
+    )?;
+    let calibrations = compute_per_spec_calibrations(&specs, &all_events_for_calibration);
+    let mut sensor = specere_filter::PerSpecTestSensor::new();
+    for (sid, cal) in &calibrations {
+        sensor.insert(sid, *cal);
+    }
     let mut processed = 0usize;
     let mut skipped = 0usize;
     // Cursor advances to the **max** observed ts, not the last-processed one —
@@ -598,7 +611,92 @@ fn run_filter_run(
         "specere filter: processed {processed} event(s), skipped {skipped}; cursor -> {}",
         out.cursor.as_deref().unwrap_or("<unchanged>")
     );
+    // FR-EQ-005 — print calibration summary. Only shows specs that have
+    // any non-default calibration (i.e., evidence events were processed).
+    // Suppressed entirely when every spec is at q=1.0 to avoid noise on
+    // v1.0.4-style repos.
+    let non_default: Vec<_> = specs
+        .iter()
+        .filter_map(|s| {
+            calibrations
+                .get(&s.id)
+                .filter(|c| (c.quality - 1.0).abs() > 1e-9)
+                .map(|c| (s.id.clone(), *c))
+        })
+        .collect();
+    if !non_default.is_empty() {
+        println!("  calibration (per spec, from mutation + smell evidence):");
+        for (sid, c) in &non_default {
+            let suspicious = if c.quality < 0.5 {
+                " ← low evidence"
+            } else {
+                ""
+            };
+            println!(
+                "    {:<24} q={:.2} α_sat={:.2} α_vio={:.2}{}",
+                sid, c.quality, c.alpha_sat, c.alpha_vio, suspicious
+            );
+        }
+    }
     Ok(())
+}
+
+/// Aggregate `mutation_result` + `test_smell_detected` events per spec
+/// into a [`Calibration`] via FR-EQ-002's formula. Specs with no evidence
+/// receive [`Calibration::prototype`] — bit-identical to v1.0.4 behaviour.
+fn compute_per_spec_calibrations(
+    specs: &[specere_filter::hmm::SpecDescriptor],
+    events: &[specere_telemetry::Event],
+) -> std::collections::HashMap<String, specere_filter::Calibration> {
+    use std::collections::HashMap;
+    // Kill-rate numerator + denominator per spec.
+    let mut caught: HashMap<String, u32> = HashMap::new();
+    let mut missed: HashMap<String, u32> = HashMap::new();
+    // Distinct test_fn × smell_kind pairs per spec (dedupe repeated lint runs).
+    let mut smells: HashMap<String, std::collections::HashSet<String>> = HashMap::new();
+
+    for e in events {
+        let kind = e.attrs.get("event_kind").map(String::as_str);
+        let spec_id = e.attrs.get("spec_id").map(String::as_str);
+        match (kind, spec_id) {
+            (Some("mutation_result"), Some(sid)) => {
+                let outcome = e.attrs.get("outcome").map(String::as_str).unwrap_or("");
+                match outcome {
+                    "caught" => *caught.entry(sid.to_string()).or_insert(0) += 1,
+                    "missed" | "timeout" => *missed.entry(sid.to_string()).or_insert(0) += 1,
+                    // "unviable" is excluded from the denominator.
+                    _ => {}
+                }
+            }
+            (Some("test_smell_detected"), Some(sid)) => {
+                let fn_name = e.attrs.get("test_fn").map(String::as_str).unwrap_or("");
+                let smell = e.attrs.get("smell_kind").map(String::as_str).unwrap_or("");
+                let key = format!("{fn_name}|{smell}");
+                smells.entry(sid.to_string()).or_default().insert(key);
+            }
+            _ => {}
+        }
+    }
+
+    let mut out: std::collections::HashMap<String, specere_filter::Calibration> =
+        std::collections::HashMap::new();
+    for spec in specs {
+        let c = caught.get(&spec.id).copied().unwrap_or(0);
+        let m = missed.get(&spec.id).copied().unwrap_or(0);
+        let kill_rate = if c + m == 0 {
+            // No mutation evidence — treat as "perfect" so prototype alphas hold.
+            1.0
+        } else {
+            c as f64 / (c + m) as f64
+        };
+        let n_smells = smells.get(&spec.id).map(|s| s.len()).unwrap_or(0) as f64;
+        let smell_penalty = (1.0 - 0.15 * n_smells).clamp(0.3, 1.0);
+        out.insert(
+            spec.id.clone(),
+            specere_filter::Calibration::from_evidence(kill_rate, smell_penalty),
+        );
+    }
+    out
 }
 
 /// Thin enum so `run_filter_run` can dispatch to HMM or BP without trait

--- a/crates/specere/tests/fr_eq_005_filter_calibration.rs
+++ b/crates/specere/tests/fr_eq_005_filter_calibration.rs
@@ -1,0 +1,242 @@
+//! FR-EQ-005 — filter-run integration: consumes mutation_result +
+//! test_smell_detected events, computes per-spec Calibration, logs
+//! the calibration summary, and uses the per-spec alphas for future
+//! test_outcome updates.
+
+mod common;
+
+use common::TempRepo;
+
+fn seed_sensor_map(repo: &TempRepo) {
+    repo.write(
+        ".specere/sensor-map.toml",
+        r#"
+schema_version = 1
+
+[specs]
+"auth"    = { support = ["src/auth/"] }
+"billing" = { support = ["src/billing/"] }
+
+[channels]
+"#,
+    );
+}
+
+fn seed_mutation_events(repo: &TempRepo, spec_id: &str, caught: u32, missed: u32) {
+    for _ in 0..caught {
+        repo.run_specere(&[
+            "observe",
+            "record",
+            "--source",
+            "cargo-mutants",
+            "--attr",
+            "event_kind=mutation_result",
+            "--attr",
+            &format!("spec_id={spec_id}"),
+            "--attr",
+            "outcome=caught",
+        ])
+        .output()
+        .expect("spawn");
+    }
+    for _ in 0..missed {
+        repo.run_specere(&[
+            "observe",
+            "record",
+            "--source",
+            "cargo-mutants",
+            "--attr",
+            "event_kind=mutation_result",
+            "--attr",
+            &format!("spec_id={spec_id}"),
+            "--attr",
+            "outcome=missed",
+        ])
+        .output()
+        .expect("spawn");
+    }
+}
+
+#[test]
+fn filter_run_uses_prototype_calibration_when_no_evidence() {
+    // With zero mutation or smell events, Calibration falls back to prototype
+    // (q=1.0). The output should match v1.0.4 behaviour. We check by running
+    // filter without evidence and confirming no "calibration" block in stdout.
+    let repo = TempRepo::new();
+    seed_sensor_map(&repo);
+    // Add a pass event so filter has something to process.
+    repo.run_specere(&[
+        "observe",
+        "record",
+        "--source",
+        "test",
+        "--attr",
+        "event_kind=test_outcome",
+        "--attr",
+        "spec_id=auth",
+        "--attr",
+        "outcome=pass",
+    ])
+    .output()
+    .expect("spawn");
+
+    let out = repo
+        .run_specere(&["filter", "run"])
+        .output()
+        .expect("spawn");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // No calibration block — every spec at q=1.0 is suppressed.
+    assert!(
+        !stdout.contains("calibration (per spec"),
+        "expected no calibration block when every spec at q=1.0; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn filter_run_reports_calibration_when_weak_tests_detected() {
+    // Seed 2 caught + 8 missed mutations for `billing` → kill_rate = 0.20.
+    // With no smells, q = 0.20 clamped to 0.30 floor.
+    let repo = TempRepo::new();
+    seed_sensor_map(&repo);
+    seed_mutation_events(&repo, "billing", 2, 8);
+    // Also need a test_outcome event so filter runs (no-new-events is a no-op).
+    repo.run_specere(&[
+        "observe",
+        "record",
+        "--source",
+        "test",
+        "--attr",
+        "event_kind=test_outcome",
+        "--attr",
+        "spec_id=auth",
+        "--attr",
+        "outcome=pass",
+    ])
+    .output()
+    .expect("spawn");
+
+    let out = repo
+        .run_specere(&["filter", "run"])
+        .output()
+        .expect("spawn");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("calibration (per spec"),
+        "expected calibration block; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("billing"),
+        "billing should appear in calibration block:\n{stdout}"
+    );
+    // q=0.30 → α_sat = 0.661, α_vio = 0.585. We look for the string "q=0.30".
+    assert!(
+        stdout.contains("q=0.30"),
+        "expected billing at q=0.30 (clamped); got:\n{stdout}"
+    );
+    // Low-quality flag fires (< 0.5).
+    assert!(
+        stdout.contains("low evidence"),
+        "expected low-evidence flag on billing:\n{stdout}"
+    );
+}
+
+#[test]
+fn filter_run_high_kill_rate_stays_near_prototype() {
+    // 18 caught + 2 missed → kill_rate = 0.90, q = 0.90.
+    // α_sat = 0.55 + 0.90*0.37 = 0.883 → "q=0.90"
+    let repo = TempRepo::new();
+    seed_sensor_map(&repo);
+    seed_mutation_events(&repo, "auth", 18, 2);
+    repo.run_specere(&[
+        "observe",
+        "record",
+        "--source",
+        "test",
+        "--attr",
+        "event_kind=test_outcome",
+        "--attr",
+        "spec_id=billing",
+        "--attr",
+        "outcome=pass",
+    ])
+    .output()
+    .expect("spawn");
+
+    let out = repo
+        .run_specere(&["filter", "run"])
+        .output()
+        .expect("spawn");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("q=0.90"),
+        "expected auth at q=0.90; got:\n{stdout}"
+    );
+    // High kill rate → NOT flagged as suspicious.
+    assert!(
+        !stdout.contains("auth")
+            || !stdout
+                .lines()
+                .any(|l| l.contains("auth") && l.contains("low evidence")),
+        "high-kill-rate spec should NOT be flagged low-evidence:\n{stdout}"
+    );
+}
+
+#[test]
+fn filter_run_smells_compress_calibration() {
+    // No mutations, but 3 smells on `auth`:
+    //   smell_penalty = 1.0 - 0.15*3 = 0.55
+    //   kill_rate = 1.0 (no mutation evidence)
+    //   q = 1.0 * 0.55 = 0.55
+    let repo = TempRepo::new();
+    seed_sensor_map(&repo);
+    for (i, smell) in ["tautological-assert", "no-assertion", "mock-only"]
+        .iter()
+        .enumerate()
+    {
+        repo.run_specere(&[
+            "observe",
+            "record",
+            "--source",
+            "specere-lint-tests",
+            "--attr",
+            "event_kind=test_smell_detected",
+            "--attr",
+            "spec_id=auth",
+            "--attr",
+            &format!("test_fn=tests::smell_{i}"),
+            "--attr",
+            &format!("smell_kind={smell}"),
+            "--attr",
+            "severity=info",
+        ])
+        .output()
+        .expect("spawn");
+    }
+    repo.run_specere(&[
+        "observe",
+        "record",
+        "--source",
+        "test",
+        "--attr",
+        "event_kind=test_outcome",
+        "--attr",
+        "spec_id=billing",
+        "--attr",
+        "outcome=pass",
+    ])
+    .output()
+    .expect("spawn");
+
+    let out = repo
+        .run_specere(&["filter", "run"])
+        .output()
+        .expect("spawn");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("q=0.55"),
+        "expected q=0.55 from 3 smells; got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
v1.0.5 second PR. Three coupled FRs:

- **#71 FR-EQ-002**: `Calibration` struct + `CalibratedTestSensor` + `PerSpecTestSensor`. Formula from plan §5. At q=1.0, output bit-identical to v1.0.4's `DefaultTestSensor`.
- **#74 FR-EQ-005**: `run_filter_run` consumes `mutation_result` + `test_smell_detected` events, builds per-spec calibration, prints summary when weak.
- **#76 FR-EQ-007**: additive event schema forward-compat.

10 new tests (6 unit + 4 integration). 208 workspace tests. All CI gates green first try on the prior release.

Bit-identical Gate-A parity (FR-P4-002) preserved — existing `gate_a_parity` tests still pass unchanged.