### PR TITLE
docs: v3 proposal — harness manager & inspector

### DIFF
--- a/docs/evidence-quality-plan.md
+++ b/docs/evidence-quality-plan.md
@@ -1,14 +1,19 @@
 # Evidence-quality execution plan (v1.0.5 → v1.1.0)
 
-**Status.** Drafted 2026-04-19. Scope + direction approved via interactive questionnaire on `docs/proposals/v2-evidence-quality.md`. No code touched yet — this plan is what lands first, reviewed, then implementation follows.
+**Status.** Drafted 2026-04-19. Scope + direction approved via interactive questionnaire on `docs/proposals/v2-evidence-quality.md`.
+
+**v1.0.5 landed 2026-04-19/20**: FR-EQ-001 (PR #88), FR-EQ-002+005+007 (PR #89), FR-EQ-003 (PR #90), FR-EQ-004 (PR #91), FR-EQ-006 (PR #92). All on main. Release tag + CHANGELOG cut deferred until v1.0.6 or v1.1.0 ships alongside (single release with combined notes is less churn).
+
+**v1.0.6 and v1.1.0 remain pending** — see §2 + §3. Current post-v1.0.5 work has pivoted to the v3 Harness Manager proposal (`docs/proposals/v3-harness-manager.md`); the user will decide whether bug-tracker (v1.0.6) or harness manager (v1.2.0) ships next.
 
 **Release shape.**
 
-| Release | Slice | Scope | FRs |
-|---|---|---|---|
-| **v1.0.5** | Mutation-calibrated sensors + test-smell detector + motion-matrix-fit + suspicious-SAT review queue | ~900 LoC, no external APIs or paid services | FR-EQ-001 … FR-EQ-007 |
-| **v1.0.6** | Bug-tracker bridge (GitHub + Gitea) | ~600 LoC, requires credentials, light LLM spend for triage (embeddings) | FR-EQ-010 … FR-EQ-013 |
-| **v1.1.0** | LLM adversary agent with hard $20/mo budget | ~800 LoC + ongoing LLM spend | FR-EQ-020 … FR-EQ-024 |
+| Release | Slice | Scope | FRs | Status |
+|---|---|---|---|---|
+| **v1.0.5** | Mutation-calibrated sensors + test-smell detector + motion-matrix-fit + suspicious-SAT review queue | ~900 LoC, no external APIs or paid services | FR-EQ-001 … FR-EQ-007 | ✅ **Landed on main** |
+| **v1.0.6** | Bug-tracker bridge (GitHub + Gitea) | ~600 LoC, requires credentials, light LLM spend for triage (embeddings) | FR-EQ-010 … FR-EQ-013 | ⏸ Deferred pending user direction |
+| **v1.1.0** | LLM adversary agent with hard $20/mo budget | ~800 LoC + ongoing LLM spend | FR-EQ-020 … FR-EQ-024 | ⏸ Deferred pending user direction |
+| **v1.2.0+** | Harness manager + inspector (new proposal) | ~1200 LoC for slices S1–S3 | FR-HM-NNN (not yet numbered) | 📝 Proposal under review (PR #93) |
 
 Each release is patch-compatible except **v1.1.0** which introduces a new CLI verb surface and bumps the minor. Patches only add event kinds + channels; the filter's public interface is unchanged.
 

--- a/docs/harness-manager-plan.md
+++ b/docs/harness-manager-plan.md
@@ -1,0 +1,324 @@
+# Harness Manager execution plan (v1.2.0 + v2.0.0)
+
+**Status.** Scope + direction approved via §10 questionnaire on `docs/proposals/v3-harness-manager.md` (2026-04-20).
+
+**Release shape (decided).**
+
+| Release | Contents | Size | Heavy deps | Status |
+|---|---|---|---|---|
+| **v1.2.0** | S1–S6 mega-release (harness scan + provenance + history + coverage + flakiness + clustering) | ~2400 LoC | `cargo-llvm-cov` subprocess (opt-in per-repo via `[specere.coverage] enabled = true`) | 📋 Planning |
+| **v2.0.0** | Tauri v2 + Sigma.js GUI; 6-screen MVP | ~frontend + ~500 LoC Rust API layer | `@sigma/core`, `graphology`, `react-flow` via Tauri shell | 📋 Parallel track |
+| **TUI** | `specere harness tui` ratatui companion | ~600 LoC | `ratatui`, `crossterm` | 🌙 Night-and-weekend parallel track |
+| **v1.0.6** (post-v2) | Bug-tracker bridge (FR-EQ-010..013) | ~600 LoC | `octocrab`, `gitea-sdk` | ⏸ Queued |
+| **v1.1.0** (post-v2) | LLM adversary (FR-EQ-020..024) | ~800 LoC | paid LLM spend | ⏸ Queued |
+
+**Policy decisions from questionnaire.**
+- **Coverage mode**: feature-flagged always-on (opt-in *per repo* via `[specere.coverage] enabled = true` in sensor-map). When flagged on, S4 runs llvm-cov alongside nextest on every test invocation; when flagged off (default), S4's CLI still works on-demand.
+- **Flakiness cold start**: ship S5 now; the per-run matrix populates from day 1. Reports surface the data we have and flag `insufficient history` under `n_runs < 50` (same pattern as FR-EQ-004).
+- **OTel semconv**: use `specere.harness.*` prefix, document in-repo as *Supplementary Semantic Convention*, propose upstream after 2+ consumers exist.
+- **GUI timing**: parallel track from S1 onwards; MVP ships as v2.0.0 alongside S6.
+- **TUI**: parallel track; share REST endpoints with GUI. Ships whenever ready.
+- **Headline story**: dual — **(1) provenance graph** (S2, demoable early) + **(2) "used-likely-along-with" coupling detection** (S4+S5 deliver it, S6 clusters it). v1.2.0 ships both.
+- **Post-v2 queue**: v1.0.6 bug-tracker bridge next.
+
+---
+
+## 1. FR numbering map
+
+| FR range | Slice | Ships in |
+|---|---|---|
+| FR-HM-001..004 | S1 — enumerate + categorise | v1.2.0 |
+| FR-HM-010..012 | S2 — provenance join | v1.2.0 |
+| FR-HM-020..022 | S3 — git version + co-modification | v1.2.0 |
+| FR-HM-030..033 | S4 — coverage co-execution | v1.2.0 |
+| FR-HM-040..043 | S5 — co-failure + flakiness | v1.2.0 |
+| FR-HM-050..052 | S6 — cluster + filter wiring | v1.2.0 |
+| FR-HM-060..061 | `specere.harness.*` OTel semconv | v1.2.0 (cross-cutting) |
+| FR-HM-070..072 | TUI companion | parallel |
+| FR-HM-080..085 | GUI v2.0.0 (6 screens) | parallel, v2.0.0 |
+
+---
+
+## 2. Slice S1 — enumerate + categorise (FR-HM-001..004)
+
+**Goal.** Every file under `src/`, `tests/`, `benches/`, `fuzz/`, `.github/workflows/`, `xtask/`, `justfile` is classified into one of nine harness categories (or explicitly `production`), with `#[test]`/`#[bench]`/`proptest!{}`/`fuzz_target!`/`insta::assert_*!` name extraction, and rendered as a harness-graph node table.
+
+**Deliverables.**
+- New CLI verb: `specere harness scan [--format toml|json]`.
+- Output: `.specere/harness-graph.toml` — sorted-by-ULID node table (TOML, matches manifest convention).
+- Output: `.specere/harness-graph.sqlite` — edge table (direct_use edges only in S1).
+- Parser for `rustc --emit=dep-info` `.d` files (read from `target/debug/deps/*.d`).
+
+**FR list.**
+
+### FR-HM-001 — `specere harness scan` enumerates all nine categories
+- **AC.** Walks `src/`, `tests/`, `benches/`, `fuzz/`, `xtask/`, `.github/workflows/`, and any file matching `justfile` or `*.just`. Classifies each `.rs` file by syn AST walker + path conventions; classifies `.yml`/`.yaml` under `.github/workflows/` as `workflow`; classifies `justfile` / `xtask/**` as `workflow`.
+- **Test plan.** 9 unit tests (one per category) using fixture repos; 2 integration tests (full-repo scan; scan with `--format json`).
+
+### FR-HM-002 — Test-name extraction per harness file
+- **AC.** For each categorised file, extract `#[test]` / `#[tokio::test]` / `#[rstest]` function names; for property files, extract `proptest!{}` identifiers; for fuzz, extract `fuzz_target!` args; for benches, extract `criterion_group!`/`#[bench]` names; for snapshots, extract `insta::assert_*!` macro call sites.
+- **Test plan.** 5 unit tests (one per harness class with test-name idioms); 1 integration test verifying the node table lists all expected test names.
+
+### FR-HM-003 — Direct-edge extraction from `rustc --emit=dep-info`
+- **AC.** Parses `target/debug/deps/*.d` files (Make-style dependency lists), filters to repo-relative paths, emits `direct_use` edges into the graph SQLite store. No rebuild required if target dir is fresh.
+- **Test plan.** 3 unit tests on `.d` parser (simple, multi-line-continuation, include_str!-derived edges); 1 integration test end-to-end against a fixture crate.
+
+### FR-HM-004 — `HarnessFile` node model + TOML serialisation
+- **AC.** The `HarnessFile` struct (see `docs/proposals/v3-harness-manager.md` §6.1) serialises stably; round-trip through `harness-graph.toml` produces bit-identical output.
+- **Test plan.** 2 unit tests (round-trip; ordering determinism); `harness-graph.toml` output is byte-identical on repeated scans (pin via `sha256` assertion in test).
+
+**Estimated LoC.** ~500. **Heavy deps.** None new (syn+walkdir already added in FR-EQ-003).
+
+---
+
+## 3. Slice S2 — provenance join (FR-HM-010..012)
+
+**Goal.** Link each harness node to the `/speckit-*` verb that created it, via existing workflow_span events.
+
+### FR-HM-010 — Workflow-span schema augmentation
+- **AC.** `.specify/extensions.yml` hooks emit `files_created` + `files_modified` in workflow spans (they already do for `after_implement`; extend to `after_specify`, `after_plan`, `after_tasks`, `after_analyze`, `after_checklist`, `after_clarify` — all 7 verbs). Attribute: comma-separated repo-rel paths.
+- **Test plan.** 7 integration tests (one per verb) verifying `files_created` attribute appears in events.jsonl after each hook fires.
+
+### FR-HM-011 — `specere harness provenance` subcommand
+- **AC.** Reads `.specere/events.jsonl`, matches `files_created`/`files_modified` to harness-graph nodes, writes `created_by` + `modified_by` edges. Populates `provenance.{creator_agent, creator_verb, creator_spec, creator_commit, creator_human, created_at}` on each node. Where agent provenance is missing (pre-harness-manager files), falls back to `git log --follow --diff-filter=A`.
+- **Test plan.** 3 integration tests (agent-created file, human-created file, divergent file where agent created but human patched).
+
+### FR-HM-012 — Divergence detection (agent vs. human edits)
+- **AC.** When a file has `created_by=WorkflowSpan` but `authored_by=Human` lines > 50%, emit `provenance_divergence_detected` advisory event (INFO severity, per v1 questionnaire).
+- **Test plan.** 2 integration tests (no divergence; heavy divergence).
+
+**Estimated LoC.** ~300. **Heavy deps.** None.
+
+---
+
+## 4. Slice S3 — git version + co-modification (FR-HM-020..022)
+
+**Goal.** Per-node churn/age/authors metrics + PPMI-on-commit-matrix edges. Reuses `specere calibrate from-git` walker.
+
+### FR-HM-020 — `git log` churn/age walker (Rust-native, no code-maat subprocess)
+- **AC.** Reimplement the subset of code-maat analyses needed: `entity-churn`, `age`, `main-dev`, `coupling`. All four emit metrics into the node table. Git log parsed via the existing `git log --name-only --numstat --follow --pretty=format:...` machinery in `calibrate/mod.rs`.
+- **Test plan.** 4 unit tests (one per analysis); 1 integration test on a fixture git repo with known commit history.
+
+### FR-HM-021 — PPMI on commit matrix → `comod` edges
+- **AC.** Same PPMI formula as in `calibrate from-git` (but applied to harness-file pairs, not spec pairs). Min-count gate: `n_joint_commits ≥ 3`. Writes `comod` edges to SQLite.
+- **Test plan.** 3 unit tests (strong coupling; below-threshold pair; single-commit spurious-coupling rejection).
+
+### FR-HM-022 — Hotspot scoring (churn × complexity)
+- **AC.** Per-node `hotspot_score = churn_rate × cyclomatic_complexity` (complexity via `syn` function-nesting walker). Rendered as top-N list in the scan output. Surfaces test-rot candidates.
+- **Test plan.** 2 unit tests + 1 integration test on a fixture with known hotspot.
+
+**Estimated LoC.** ~400. **Heavy deps.** None (reuses existing git log pipeline).
+
+---
+
+## 5. Slice S4 — coverage co-execution (FR-HM-030..033)
+
+**Goal.** Per-test coverage bitvectors → Jaccard → `cov_cooccur` edges. Feature-flagged always-on via `[specere.coverage] enabled = true`.
+
+### FR-HM-030 — `cargo-llvm-cov` driver
+- **AC.** Subprocess `cargo llvm-cov nextest --no-report --profraw-only` with per-test profraw output enabled. Collects one `.profraw` file per test binary × test name. Handles `--features` + `--target` permutations (keys each coverage vector by `(test, features, target)`).
+- **Test plan.** 2 integration tests (single-target run; feature-flag permutation). Tests gated behind `cfg(feature = "cov-integration")` so CI without llvm tools still passes.
+
+### FR-HM-031 — `llvm-profdata` merge + bitvector extraction
+- **AC.** Subprocess `llvm-profdata merge` + `llvm-cov export --format=lcov --instr-profile=...`. Parses LCOV to extract `covered_line_bitvector` per test. Stores bitvectors in SQLite keyed by `(test, features, target)`.
+- **Test plan.** 3 unit tests on LCOV parser; 1 integration test that bitvector round-trips.
+
+### FR-HM-032 — Jaccard similarity → `cov_cooccur` edges
+- **AC.** For every pair `(a, b)` with non-empty bitvectors, compute `J_cov = |C(a)∩C(b)| / |C(a)∪C(b)|`. Emit `cov_cooccur` edge with weight=J_cov when J_cov > 0.1 (pruning threshold). Runtime scales O(n² · avg_vector_len); use roaring bitmaps for large repos.
+- **Test plan.** 3 unit tests (disjoint=0; identical=1; partial overlap).
+
+### FR-HM-033 — `[specere.coverage] enabled` sensor-map flag
+- **AC.** When `true`, `specere harness scan` automatically invokes S4 at the end of S3. When `false` (default), `specere harness coverage` is only run on-demand.
+- **Test plan.** 2 integration tests (flag on; flag off).
+
+**Estimated LoC.** ~600. **Heavy deps.** `cargo-llvm-cov` + `llvm-profdata` subprocess; `roaring` crate for compact bitvectors (optional — v1.2.0 uses `BitVec` if repo <1000 tests).
+
+---
+
+## 6. Slice S5 — co-failure + flakiness (FR-HM-040..043)
+
+**Goal.** Per-run JUnit matrices → PPMI-on-failures edges, with DeFlaker-style coverage filter + Meta prob-flakiness gating.
+
+### FR-HM-040 — Per-run JUnit ingestion
+- **AC.** New hook in `.specify/extensions.yml`: `after_test_run` reads the nextest-emitted JUnit XML at `target/nextest/*/junit.xml`, persists per-test pass/fail outcome as event-store rows.
+- **Test plan.** 2 integration tests (first run; accumulating runs).
+
+### FR-HM-041 — PPMI on `test × run` matrix → `cofail` edges
+- **AC.** Accumulates matrix in SQLite; `cofail` edges emitted only when `n_joint_failures ≥ 5` (Hoeffding gate). Edges are signed: `PPMI_fail > 0` means co-coupled, negative truncated to 0.
+- **Test plan.** 3 unit tests (coupled pair; anti-correlated pair; below-threshold pair).
+
+### FR-HM-042 — DeFlaker-style flakiness filter
+- **AC.** For each failing test, check whether its coverage bitvector (from S4) intersects the diff of the failing commit. If no intersection → mark `probable_flake`. Discount flaky tests' contribution to `cofail` PPMI by `(1 - P_flake)`.
+- **Test plan.** 3 unit tests (genuine fail; pure flake; ambiguous).
+
+### FR-HM-043 — Meta probabilistic-flakiness score
+- **AC.** Per-test `P(fail | good_state)` estimated from recent history. Stored on `HarnessFile.flakiness_score`. Surfaced in `specere harness flaky` report with `insufficient history` warning when `n_runs < 50`.
+- **Test plan.** 2 unit tests (stable test; known-flake).
+
+**Estimated LoC.** ~500. **Heavy deps.** `junit-parser` crate (~200 LoC alternative, pure-Rust). Requires S4 for DeFlaker filter (dependency gate).
+
+---
+
+## 7. Slice S6 — cluster + filter wiring (FR-HM-050..052)
+
+**Goal.** Run Leiden on the combined edge graph; emit `[harness_cluster]` into sensor-map; wire cluster belief into the existing BBN.
+
+### FR-HM-050 — Leiden community detection
+- **AC.** Constructs weighted undirected graph G over harness nodes with composite weight = `0.4·J_cov + 0.3·σ(PPMI_fail) + 0.2·σ(PPMI_mod) + 0.1·σ(w_indirect)` (sub-scores stored raw in SQLite; composite computed on demand). Runs `graphina::leiden` (or `single-clustering::leiden`) with deterministic seed (read from sensor-map `[harness_cluster] seed`). Assigns `cluster_id` to every node.
+- **Test plan.** 3 unit tests (two tightly coupled clusters produce two clusters; disconnected nodes produce singletons; empty graph yields empty output).
+
+### FR-HM-051 — Sensor-map `[harness_cluster]` export
+- **AC.** Writes `.specere/sensor-map.toml`'s `[harness_cluster]` section:
+  ```toml
+  [harness_cluster]
+  algo = "leiden"
+  seed = 42
+  auto_emit = true
+
+  [harness_cluster.clusters."C01"]
+  members = ["tests/fr_eq_003_lint_tests.rs", ...]
+  centroid_spec = "FR-EQ-003"
+  ```
+- **Test plan.** 2 integration tests (new run writes cluster table; re-run with same seed produces byte-identical output).
+
+### FR-HM-052 — Cluster-belief integration with BBN
+- **AC.** Extend `PerSpecTestSensor` to accept a `cluster_id` → `Calibration` map. When a harness file in cluster C fires a test outcome, the calibration for the *cluster* is used as a prior on the per-spec calibration. Fallback: prototype alphas when cluster data absent.
+- **Test plan.** 2 unit tests (cluster-calibration applied; missing-cluster fallback) + 1 integration test (two specs share a cluster → their posteriors move together).
+
+**Estimated LoC.** ~400. **Heavy deps.** `graphina` (Louvain+Leiden, pure Rust) OR `single-clustering` (Leiden alone) — pick based on v1.2.0 implementation audit. Wire into existing BBN via the FR-EQ-002 `Calibration` struct.
+
+---
+
+## 8. Cross-cutting — `specere.harness.*` OTel semconv (FR-HM-060..061)
+
+### FR-HM-060 — Attribute set definition
+- **AC.** Document the following supplementary attributes in `docs/otel-specere-semconv.md`:
+  - `specere.harness.kind` — one of nine categories
+  - `specere.harness.file` — repo-rel path
+  - `specere.harness.test_name` — extracted test name
+  - `specere.harness.cluster_id` — post-S6 cluster assignment
+  - `specere.harness.coverage_digest` — blake3 of production lines
+  - `specere.harness.provenance.speckit_unit` — creator `/speckit-*` verb
+  - `specere.harness.flakiness_score` — [0, 1]
+- **Test plan.** 1 contract test in `crates/specere-telemetry/tests/` that every emitted harness-event populates these attributes correctly.
+
+### FR-HM-061 — All S1–S6 subcommands emit these attributes
+- **AC.** Every new event kind (`harness_scan`, `harness_provenance`, `harness_history`, `harness_coverage`, `harness_flaky`, `harness_cluster`) carries the supplementary attribute set. Additive-event-schema rule (FR-EQ-007) enforced: unknown kinds still parse, cursor still advances.
+- **Test plan.** 6 integration tests (one per subcommand) verifying attribute presence.
+
+**Estimated LoC.** ~100 (documentation + attribute plumbing in existing event_store). **Heavy deps.** None.
+
+---
+
+## 9. TUI parallel track (FR-HM-070..072)
+
+### FR-HM-070 — `specere harness tui` main shell
+- **AC.** ratatui shell with sidebar (file tree + cluster list) + main pane (node detail); reads from SQLite + REST endpoints exposed by `specere serve http`. Entrypoint: `specere harness tui`.
+- **Test plan.** 2 unit tests (nav keybindings; layout rendering).
+
+### FR-HM-071 — Relation inspector mini-view
+- **AC.** Press Enter on a node → modal listing all incoming/outgoing edges grouped by type. Press Esc to return. Keyboard-first (j/k navigation).
+- **Test plan.** 2 integration tests (render; select-and-return).
+
+### FR-HM-072 — Event timeline TUI
+- **AC.** Bottom pane shows live OTel span stream filtered by verb. Auto-refreshes every 1s.
+- **Test plan.** 1 integration test (mock stream populates pane).
+
+**Estimated LoC.** ~600. **Heavy deps.** `ratatui`, `crossterm`.
+
+---
+
+## 10. GUI parallel track v2.0.0 (FR-HM-080..085)
+
+Six screens in a Tauri v2 shell. Frontend: Sigma.js + Graphology + React Flow (per research report §GUI).
+
+### FR-HM-080 — Tauri shell + Axum API extension
+- **AC.** `specere gui` launches a Tauri shell hosting the existing `specere serve http` Axum server as its backend. New endpoints:
+  - `GET /api/v1/harness/graph?format=graphology`
+  - `GET /api/v1/harness/files/{path}/relations`
+  - `GET /api/v1/harness/clusters?algo=leiden`
+  - `GET /api/v1/specs/{id}/harness`
+  - `GET /api/v1/events/ws` (WebSocket for live updates)
+- **Test plan.** REST contract tests in `crates/specere/tests/fr_hm_080_*.rs`.
+
+### FR-HM-081 — Harness Graph screen (Sigma.js + FA2-in-worker)
+- **AC.** Renders `/api/v1/harness/graph` via Sigma.js WebGL renderer; force-directed layout via Graphology's `graphology-layout-forceatlas2` in a WebWorker. Colour by cluster; size by posterior entropy.
+- **Test plan.** Playwright E2E test renders 100-node fixture graph.
+
+### FR-HM-082 — Spec Dashboard
+- **AC.** Per-spec UNK/SAT/VIO stacked-bar simplex + timeline sparkline. Reads `/api/v1/specs` + `/api/v1/specs/{id}/timeline`.
+- **Test plan.** Component test with fixture data.
+
+### FR-HM-083 — Review Queue (markdown-backed Kanban)
+- **AC.** Three-column Kanban parsed from `.specere/review-queue.md`; drag-and-drop state changes write back to markdown preserving plaintext source-of-truth. Keyboard-first: J/K navigate, E extend, I ignore, A allowlist, D adjudicate.
+- **Test plan.** E2E test verifies markdown round-trip on state change.
+
+### FR-HM-084 — Event Timeline (Perfetto-style waterfall)
+- **AC.** Chronological span viewer with row-per-trace-ID. Click span → attribute panel.
+- **Test plan.** E2E test with fixture OTel trace.
+
+### FR-HM-085 — Relation Inspector (deep-link modal)
+- **AC.** Click a node anywhere → split-pane opens with 2-hop neighbourhood (React Flow) + tabbed detail pane (Relations, Specs, Spans, Review items). Deep-linkable via `specere://file/<path>` custom scheme.
+- **Test plan.** E2E test verifies deep-link opens correct node.
+
+**Estimated LoC.** ~500 Rust (API layer) + ~3000 JS/TS (frontend). **Heavy deps (frontend)**: `@sigma/core`, `graphology`, `react-flow`, `@tauri-apps/api`.
+
+---
+
+## 11. Dependency graph
+
+```
+S1 (FR-HM-001..004) → S2 (FR-HM-010..012) → S3 (FR-HM-020..022) → S4 (FR-HM-030..033) → S5 (FR-HM-040..043) → S6 (FR-HM-050..052)
+                                                                       ↘ (S5 needs S4 for DeFlaker)
+FR-HM-060..061 cross-cuts all six.
+TUI (FR-HM-070..072) can begin after S3.
+GUI (FR-HM-080..085) API layer can begin at S1; screens populate as slices land.
+```
+
+S1 → S2 → S3 is hard-sequential (S2 needs S1 nodes; S3 needs S1 nodes but is independent of S2).
+S4 is independent of S2/S3 but most valuable after them.
+S5 depends on S4 (DeFlaker coverage join).
+S6 needs all edge types in place.
+
+---
+
+## 12. Exit criteria for v1.2.0
+
+- All 6 slices landed on main with integration tests.
+- `specere harness scan` on ReSearch (dogfood target) produces a classified inventory of ≥ 50 harness files within 60 seconds.
+- `specere harness provenance` attributes ≥ 80% of existing harness files to a `/speckit-*` verb (self-dogfood test).
+- `specere harness flaky` on ≥50-run CI history from SpecERE itself produces at least one correctly-identified flake pair.
+- Cluster output at `.specere/sensor-map.toml` is byte-identical on repeated runs (same seed).
+- Full workspace `cargo test` green; clippy clean.
+- CHANGELOG entry + README updated.
+
+## 13. Exit criteria for v2.0.0 (GUI)
+
+- Tauri shell launches on linux/macOS/windows.
+- All 6 screens render fixture data.
+- 10k-node graph test renders at ≥30fps (Sigma.js + FA2 worker benchmark).
+- Markdown round-trip on review-queue state change preserves byte-identity of untouched entries.
+- REST endpoints covered by contract tests.
+
+---
+
+## 14. Re-planning triggers
+
+If any of these occur, pause implementation and revisit the plan:
+- `cargo-llvm-cov` integration cost exceeds 3× test-suite wall-clock (not 2-3× as research estimated).
+- Leiden clustering produces ≥50% singleton clusters on ReSearch (signal-to-noise too low).
+- Agent-provenance attribution in S2 drops below 30% coverage (workflow-span hooks missing data).
+- GUI MVP blocks on a missing OSS library (Sigma.js perf cliff, React Flow regression).
+- User requests scope change.
+
+## 15. Not in this plan (defer)
+
+- SLSA/in-toto cryptographic provenance — overkill for use case.
+- FlakeFlagger-class ML-based flakiness prediction — requires training pipeline.
+- Cross-repo SCIP indexing — only after multi-repo SpecERE users exist.
+- Upstream OTel `test.*` semconv RFC — after 2+ consumers, per questionnaire Q7.
+- Predictive test selection (Meta-style GBDT) — future phase; would reuse v1.2.0's data pipeline.
+
+---
+
+*End of plan. Next: begin S1 (FR-HM-001..004). First PR: `docs/harness-manager-plan.md` + scaffold `crates/specere/src/harness/mod.rs`.*

--- a/docs/proposals/v3-harness-manager.md
+++ b/docs/proposals/v3-harness-manager.md
@@ -1,0 +1,288 @@
+# SpecERE v3 — Harness Manager & Inspector
+
+**Proposal status**: Draft — awaiting go/no-go + prioritisation. **Next action**: user reviews §1 premise + §10 questionnaire, picks a scope, then we cut FR numbers and begin Slice 1.
+
+**Paired document**: `docs/harness-manager-plan.md` (FR-numbered execution plan; to be written after go/no-go).
+
+---
+
+## 1 · Premise — what's missing today
+
+SpecERE already observes an agentic workflow (OTel spans, SpecKit verbs) and maintains a per-spec Bayesian belief over `UNK/SAT/VIO` with evidence-quality calibration (v1.1 work, see `docs/evidence-quality-plan.md`). What it does **not** do is treat the *test surface itself* as a first-class object.
+
+Today, every `#[test]`, every `tests/*.rs`, every `benches/`, every CI YAML is a file path in the sensor-map at best. The user cannot ask:
+
+- "Which tests are *actually testing* this spec — not just declared to?"
+- "Which tests co-fail consistently — are they really testing two things or one?"
+- "Who/what created this test — a human in issue #42, or `/speckit-implement` on spec `002-phase-1-bugfix`?"
+- "This helper fixture is shared by 18 tests across 4 specs — what happens if I edit it?"
+- "Our property-based tests under `proptest!` last ran 6 months ago — has the code they exercise changed since?"
+
+A **harness manager** promotes the test surface from an opaque input into a **typed, provenanced, clustered graph** over which SpecERE's belief engine can reason. It is the natural v3 move after v1.0/v1.1's evidence-quality work: the evidence-quality layer fixed "when do we trust a test's verdict"; the harness manager fixes "*which tests do we even have, and how do they relate?*"
+
+---
+
+## 2 · Scope — what is a "harness file"?
+
+Nine categories, each detectable statically (cheap):
+
+| Category | Detection | Example |
+|---|---|---|
+| `unit` | `src/**/*.rs` with `#[cfg(test)]` + `#[test]` | Inline module tests |
+| `integration` | `tests/*.rs` (Cargo convention) | `tests/fr_eq_003_lint_tests.rs` |
+| `property` | `proptest!{}` / `#[quickcheck]` / `bolero::check!` | Property tests |
+| `fuzz` | `fuzz/fuzz_targets/**` / `libfuzzer_sys::fuzz_target!` | Fuzz corpora |
+| `bench` | `benches/**` / `criterion_group!` / `#[bench]` | Criterion benches |
+| `snapshot` | Files matching `insta::assert_*!` + `*.snap` | Snapshot tests |
+| `golden` | Files named `*.expected.*`, `fixtures/**/*.json` | Golden data |
+| `mock` | `mockall!` macros, files named `mock_*.rs` | Mocks |
+| `fixture` | `tests/common/**`, `tests/fixtures/**` | Shared helpers |
+| `workflow` | `.github/workflows/*.yml`, `.gitlab-ci.yml`, `justfile`, `xtask/**` | CI/orchestration |
+
+---
+
+## 3 · Relation taxonomy — what edges SpecERE should track
+
+Six relation families. Every family has a **precise definition**, a **Rust-ecosystem detection recipe**, and a **noise source**:
+
+### 3.1 Direct linkage (zero-cost, high-signal)
+- **Definition**: `a → b` iff `a`'s source text contains a resolvable `use`/`mod`/`include_str!`/macro invocation whose target is `b`.
+- **Source**: `rustc --emit=dep-info` produces `.d` files per target on every build — free. Optionally augmented by SCIP (rust-analyzer's cross-reference index) for symbol-level edges.
+- **Noise**: near-zero.
+
+### 3.2 Indirect linkage (shared fixture/helper/mock)
+- **Definition**: `a ↔ b` iff they share a third node `h` that is not ubiquitous.
+- **Source**: graph query `common_neighbors(a, b)` over the direct graph, filtered by an IDF weighting on `h` (helpers used by 90% of tests contribute ~0; helpers used by 3 contribute strongly).
+- **Noise**: low, after IDF filter.
+
+### 3.3 Co-execution (coverage footprint)
+- **Definition**: `J_cov(a, b) = |C(a) ∩ C(b)| / |C(a) ∪ C(b)|` where `C(t)` is the set of production lines `t` covered.
+- **Source**: `cargo llvm-cov --no-report` + per-test profraw files, merged via `llvm-profdata`. ~2-3× test suite overhead; opt-in.
+- **Noise**: medium — feature-flag permutations produce different coverage, must key by `(test, features, target)`.
+
+### 3.4 Co-failure (CI history)
+- **Definition**: `PPMI_fail(a, b) = max(0, log₂(p(a,b) / (p(a)·p(b))))` over the last N CI runs.
+- **Source**: nextest JUnit XML or libtest JSON output, persisted per run in SpecERE's event store.
+- **Noise**: **HIGH** unless DeFlaker-style coverage filter + Meta's probabilistic flakiness score are applied first. Flaky tests co-fail by chance; must be de-biased.
+
+### 3.5 Co-modification (git history)
+- **Definition**: Same PPMI formula applied to commit co-membership.
+- **Source**: Reuses `specere calibrate from-git` pipeline verbatim — the algorithm is already in the codebase, just needs a second consumer.
+- **Noise**: medium; churn-heavy files dominate without care.
+
+### 3.6 Provenance (who/what created this)
+- **Definition**: Each harness file has a `(creator_agent, creator_verb, creator_spec, creator_commit, creator_human, created_at)` tuple.
+- **Source**:
+  - **Agent provenance**: SpecERE's existing workflow-span hooks (`after_implement`, `after_specify`). Join `files_created` attrs to the harness node — SpecERE **already has this data**; no new collection needed.
+  - **Human provenance**: `git log --follow --diff-filter=A` for creation commit; `git blame` + `.mailmap` for line-level authorship.
+  - **Divergence**: agent wrote file but a human patched it → record as `modified_by` edges, which is itself a signal.
+- **This is SpecERE's unique surface**: no academic or industry tool fuses agent-span provenance with test-dependency graphs. Cursor's Agent-Trace RFC is the closest analogue and publishes only a JSON attribution side-channel.
+
+### 3.7 Version / lineage (for "is this test rotting?")
+- **Metrics**: `(age_days, total_commits, distinct_authors, churn_rate, last_touched, bus_factor)`.
+- **Source**: subprocess `code-maat -a entity-churn -a age -a main-dev` (Adam Tornhill's Clojure tool) or a thin Rust reimplementation over `git log --numstat`. Reuses existing `calibrate from-git` walkers.
+- **Noise**: low for large repos.
+
+---
+
+## 4 · Formal "used likely along with" score
+
+For each pair `(a, b)`, SpecERE computes three raw sub-scores and a composite:
+
+```
+J_cov(a, b)    = |C(a) ∩ C(b)| / |C(a) ∪ C(b)|            ∈ [0, 1]
+PPMI_fail(a, b) = max(0, log₂(p_fail(a,b) / (p_fail(a)·p_fail(b))))
+PPMI_mod(a, b)  = max(0, log₂(p_mod(a,b) / (p_mod(a)·p_mod(b))))
+w_indirect(a, b) = Σ_h [h ∈ N(a) ∩ N(b)] · log(|H| / df(h))
+S(a, b) = 0.4·J_cov + 0.3·σ(PPMI_fail) + 0.2·σ(PPMI_mod) + 0.1·σ(w_indirect)
+```
+
+where `σ(x) = 1 − exp(−x)` is a saturating normaliser. **`S` is a sort key for the UI only; downstream queries consume the raw sub-scores separately.** Collapsing them too early erases information (coverage + co-failure tell you "tests of the same thing"; co-modification tells you "tests that happen to get edited together" — different conclusions).
+
+Significance gates: require `n_joint_failures ≥ 5` before a PPMI_fail is reported (Hoeffding-style); require `n_joint_commits ≥ 3` for PPMI_mod (matches existing `min_commits` default in `calibrate from-git`).
+
+---
+
+## 5 · Novel SpecERE surface vs. prior art
+
+Four items are genuinely new:
+
+| # | Novel surface | Why no one else has it |
+|---|---|---|
+| 1 | **Bayesian cluster-belief updates over agentic spans** | Meta's Predictive Test Selection (ICSE 2019) is a GBDT on commits; SpecERE fuses OTel GenAI spans + coverage + clustering + BBN into a live posterior. |
+| 2 | **Harness-provenance graph** linking each test to the `/speckit-*` verb that produced it | Every academic paper treats tests as ahistorical. SpecERE's workflow spans carry authoritative lineage. |
+| 3 | **Heterogeneous harness-class awareness** — cluster within + across unit/property/fuzz/bench/snapshot | Academic tools assume one test kind. Real Rust repos mix nine. |
+| 4 | **Supplementary `specere.harness.*` semantic convention** | OTel 1.40 has `cicd.*` + `gen_ai.*` but **no `test.*` namespace** (SIG hasn't landed it). SpecERE can slot in a vendor-prefixed convention and RFC upstream later. |
+
+Everything else — coverage collection, test sharding, mutation testing, clustering algorithms, graph rendering — is **composition over existing OSS** (see §7).
+
+---
+
+## 6 · Data model sketch
+
+### 6.1 Node: `HarnessFile` (one per test/fixture/workflow source)
+```toml
+id                 = "01HW..."           # ULID, stable across git moves
+path               = "tests/fr_eq_003_lint_tests.rs"
+prior_paths        = []                  # follow renames via `git log --follow`
+category           = "integration"        # one of nine
+category_confidence = 1.0
+crate              = "specere"
+test_names         = ["emits_one_event_per_smell_with_spec_attribution", ...]
+provenance = { creator_agent = "claude-4.7",
+               creator_verb = "/speckit-implement",
+               creator_spec = "043-fr-eq-003-smell-detector",
+               creator_commit = "2378809...",
+               creator_human = "laiadlotape",
+               created_at = "2026-04-19T22:40:00Z" }
+version_metrics = { age_days = 1, commits = 3, authors = 1, churn_rate = 0.0,
+                    last_touched = "2026-04-19T23:00:00Z", bus_factor = 1 }
+flakiness_score    = 0.0                 # 0 if unknown
+coverage_hash      = "blake3:..."         # digest of production lines it covers
+platform_tags      = ["cfg(unix)", "cfg(feature = \"syn\")"]
+tier               = "fast"               # fast | slow | serial (from nextest + timing)
+```
+
+### 6.2 Edges (nine types)
+| Type | Direction | Weight source | Confidence |
+|---|---|---|---|
+| `direct_use` | a → b | 1.0 | 1.0 |
+| `shared_helper` | a ↔ b | TF-IDF on shared h | 0.9 |
+| `dep_overlap` | a ↔ b | Jaccard on crate deps | 0.7 |
+| `cov_cooccur` | a ↔ b | Jaccard on coverage bitvector | 0.8 |
+| `cofail` | a ↔ b | PPMI on CI run matrix | 0.5 |
+| `comod` | a ↔ b | PPMI on commit matrix | 0.6 |
+| `created_by` | a → WorkflowSpan | 1.0 | 1.0 |
+| `modified_by` | a → WorkflowSpan | #lines touched | 0.9 |
+| `authored_by` | a → Human | fraction of lines | 0.8 |
+
+Weights are **not comparable across types**. Edges are *stored raw* and *composed per query*.
+
+### 6.3 Persistence
+- Node table → `.specere/harness-graph.toml` (sorted by `id`, deterministic output, TOML fits existing manifest conventions).
+- Edge tables → `.specere/harness-graph.sqlite` (rusqlite, same crate SpecERE already uses for events).
+- Derived cluster IDs → `.specere/harness-clusters.toml` (pastable into sensor-map for filter priors).
+
+---
+
+## 7 · Tech stack — compose-never-clone scorecard
+
+### 7.1 Rust crates to pull in (Tier A, must-have)
+| Crate | Role |
+|---|---|
+| `petgraph` | Core graph ADT. Already supports everything we need. |
+| `walkdir` | Filesystem enumeration (already a dep from FR-EQ-003). |
+| `syn` | AST walking for category/test-name extraction (already a dep). |
+| `graphina` or `single-clustering` | Louvain + Leiden community detection. |
+| `linfa-clustering` | HDBSCAN over coverage embeddings for outlier detection. |
+| `tree-sitter-stack-graphs` | Cross-crate reference edges (complements SCIP). |
+| `rusqlite` | Edge store (already a dep). |
+
+### 7.2 External CLIs to subprocess (Tier B)
+| Tool | Role |
+|---|---|
+| `cargo-nextest` | Test enumeration, JSON output, groups, partition. **Do not reimplement.** |
+| `cargo-llvm-cov` | Per-test coverage (profraw). **Do not reimplement.** |
+| `code-maat` | Churn/age/coupling analyses. Subprocess-only; don't port. |
+| `cargo-mutants` | Already wired (FR-EQ-001); reuse its spec-attribution for sensitivity scores. |
+
+### 7.3 Explicit non-build list (what we will NOT do)
+- Do **not** reimplement Ekstazi/STARTS — leverage dep-info + llvm-cov instead.
+- Do **not** write our own Louvain/Leiden — crates exist.
+- Do **not** train or fine-tune embedding models — defer until v4 if ever.
+- Do **not** implement cryptographic provenance (SLSA/in-toto) — premature for the use case.
+
+---
+
+## 8 · GUI — future-proofing the data pipe
+
+The user flagged that SpecERE will get a GUI. The data model in §6 is designed to serve both CLI and GUI from the same REST endpoints exposed by the existing `specere serve http` Axum server.
+
+### 8.1 Recommended stack (research §GUI)
+- **Shell**: Tauri v2 — native, 600KB binaries, reuses `specere serve http` as the backend.
+- **Graph rendering**: Sigma.js + Graphology (WebGL, 10k+ node fluid), layouts via ForceAtlas2 in a WebWorker.
+- **Inspector panels**: React Flow (DOM-level node customisation, context menus, edge labels).
+- **Fallback** (no-JS path): egui + `egui_graphs` single-binary Rust GUI for <1k-node repos.
+- **Companion TUI**: ratatui — parallel track, not a replacement.
+
+### 8.2 Core screens (v2 GUI)
+1. **Harness Graph** — force-directed, coloured by cluster, sized by posterior entropy.
+2. **Spec Dashboard** — per-spec UNK/SAT/VIO simplex + timeline sparkline.
+3. **Review Queue** — markdown-backed Kanban (read `.specere/review-queue.md`, write back on state change).
+4. **Event Timeline** — OTel waterfall of workflow spans (Perfetto-style).
+5. **Relation Inspector** — "click a file, see all its edges" deep-link modal.
+6. **Calibration View** — scatter of predicted vs. empirical posterior per spec.
+
+### 8.3 New read-side Axum endpoints (CLI-first, GUI-ready)
+- `GET /api/v1/harness/graph?format=graphology` — full graph as Graphology JSON.
+- `GET /api/v1/harness/files/{path}/relations` — 2-hop neighbourhood + edge types.
+- `GET /api/v1/harness/clusters?algo=leiden` — pre-computed cluster assignments.
+- `GET /api/v1/specs/{id}/harness` — which harness files test this spec.
+- `GET /api/v1/events/ws` — WebSocket stream of live span arrivals.
+
+### 8.4 CLI-first rule
+Every GUI-facing endpoint must be reachable via CLI first. Example: `specere harness graph --format json` before we write the graph view. GUI is a second consumer, never the only one.
+
+---
+
+## 9 · Implementation slices (priority order)
+
+Six slices, each independently useful, ship-by-ship:
+
+| Slice | Scope | Cost | Ship gate |
+|---|---|---|---|
+| **S1 · Enumerate + categorise** | Walk `src/`/`tests/`/`benches/`/`fuzz/`; classify into nine categories; extract `#[test]` names. New CLI: `specere harness scan`. | ~500 LoC | Direct linkage from `dep-info`. Categories cover 95% of repos. |
+| **S2 · Provenance join** | Read existing workflow spans; match `files_created` to S1 nodes. New CLI: `specere harness provenance`. | ~300 LoC | Every node has a `creator_span_id` when available. |
+| **S3 · Git version + co-modification** | Add code-maat-style churn + PPMI on commit matrix. Reuses `calibrate from-git`. New CLI: `specere harness history`. | ~400 LoC | Hotspot report matches Tornhill "Your Code as a Crime Scene" output. |
+| **S4 · Coverage co-execution** | Opt-in `cargo-llvm-cov` integration; Jaccard on coverage bitvectors. New CLI: `specere harness coverage --with-nextest`. | ~600 LoC | At least one real-world repo's `J_cov > 0.8` pairs all reflect genuine coupling. |
+| **S5 · Co-failure + flakiness** | Persist per-run JUnit into event store; PPMI + DeFlaker coverage-join + Meta prob-flakiness. New CLI: `specere harness flaky`. | ~500 LoC | Classifies 70%+ of known flakes in a seed project. |
+| **S6 · Cluster + filter wiring** | Leiden on the combined edge graph; emit `[harness_cluster]` section into sensor-map; wire cluster belief into existing BBN. New CLI: `specere harness cluster`. | ~400 LoC | Cluster IDs become priors over FR groups; filter picks them up without code change. |
+
+**S1–S3 ship together as v1.2.0** (~1200 LoC, no new heavy deps, pure value-add).
+**S4–S5 ship as v1.3.0** (coverage is opt-in; flakiness needs historical data).
+**S6 ships as v1.4.0** (the Bayesian integration that closes the loop).
+**GUI is v2.0.0** (6-screen MVP on Tauri).
+
+---
+
+## 10 · Questionnaire for go/no-go
+
+Before we write the FR-numbered plan, please answer:
+
+1. **Scope of first release.** v1.2.0 = S1+S2+S3 (harness scan + provenance + history). Right?
+2. **Release cadence.** Do we cut v1.2.0 as a patch-level release like v1.0.5/6, or do we target crates.io publication for v1.2? (Reminder: SpecERE is not on crates.io today per `MEMORY.md` pivot notes.)
+3. **Coverage collection cost.** S4 doubles test-suite wall-clock time. Opt-in (`specere harness coverage` only when user runs it) or always-on behind a feature flag?
+4. **Flakiness minimum data.** S5 needs ≥50 CI runs of history. Do we build it now and wait for data, or defer until a real SpecERE consumer has that history?
+5. **GUI timing.** Tauri + Sigma.js MVP is ~4-6 weeks. Ship *before* S6 (so users can see the data as we build it), *after* S6 (so all the data exists to visualise), or *in parallel* on a separate track?
+6. **TUI companion.** Is a `specere harness tui` (ratatui) worth a night-and-weekend track? Power users would love it; it also serves as the CLI→GUI bridge.
+7. **Supplementary OTel semconv.** Do we formalise `specere.harness.*` attributes and RFC upstream to the OTel CI/CD SIG, or stay vendor-private?
+8. **Novel Bayesian surface priority.** Is the "cluster-belief-update over agentic spans" (the genuinely novel §5-#1 item) valuable enough to be the headline feature, or is the provenance graph (§5-#2) the more defensible story for users?
+
+Your answers pin down v1.2.x/v1.3.x/v1.4.x/v2.0 release timing and what each contains. Then I cut FR-HM-001..NNN and begin S1.
+
+---
+
+## 11 · Risks
+
+- **Coverage overhead**. 2-3× test-suite time. S4 must be opt-in and well-documented.
+- **Flakiness filter quality**. Without DeFlaker-style coverage-join, co-failure edges will be mostly noise. Ship order (S4 before S5) is non-negotiable.
+- **Provenance divergence**. If an agent writes a file and a human immediately rewrites it, the creator_agent field misleads. We record both; the reviewer decides. Must document in S2.
+- **Cluster instability**. Leiden is deterministic only with a fixed seed. Document seed policy before S6.
+- **GUI scope creep**. The MVP is 6 screens. Resist adding a 7th until users ask.
+- **Monorepo scaling**. 10k+ harness files per repo exist. Sigma.js + FA2 handles 10k; past that, hierarchical collapse + LOD rendering kicks in.
+- **Compose risk**. `code-maat` is Clojure; `cargo-llvm-cov` wraps llvm-profdata. Both add subprocess dependencies. Fall-back plans: pure-Rust git log walker (already built); accept tarpaulin as macOS fallback where llvm-cov is slower.
+
+---
+
+## 12 · Research sources
+
+See the three deep-research briefs attached:
+- **§SoA** — 30+ URLs on RTS, predictive test selection, flakiness detection, code-graph protocols.
+- **§Relation taxonomy** — formal PPMI/Jaccard derivations, Ekstazi/STARTS/DeFlaker/FlakeFlagger citations.
+- **§GUI** — Tauri v2 / Sigma.js / egui_graphs benchmark comparisons, 6-screen UX sketch.
+
+Full URL bibliography kept in the agent research transcripts at `.claude/projects/.../tasks/{aa54daca,a76089a1,a1a9c4ad}.output`.
+
+---
+
+*End of proposal. Reviewer: answer §10 questionnaire; reply "go" + choices; I will cut FR numbers and start S1.*


### PR DESCRIPTION
## Summary

Deep-research-backed proposal for a **harness manager and inspector** in SpecERE v1.2.0 → v2.0. Response to user request for "a big analysis on this topic" covering:

- Automatic clustering of harness files (tests, fixtures, mocks, benches, fuzz, snapshots, CI workflows) into nine categories.
- Six relation families: direct linkage, indirect linkage (shared helpers), coverage co-execution, CI co-failure, git co-modification, provenance.
- A formal PPMI/Jaccard-based "used likely along with" score.
- A tech stack that **composes existing OSS** — petgraph, syn, walkdir, graphina (Louvain/Leiden), tree-sitter-stack-graphs, rustc \`--emit=dep-info\`, cargo-nextest, cargo-llvm-cov, code-maat, cargo-mutants (reused from FR-EQ-001).
- Four genuinely novel surfaces that no other tool has: Bayesian cluster-belief updates over agentic OTel spans, harness-provenance graph linking each test to the \`/speckit-*\` verb that produced it, heterogeneous harness-class awareness, supplementary \`specere.harness.*\` semantic convention.
- A six-slice implementation plan (S1–S6) with cost estimates.
- A GUI stack recommendation (Tauri v2 + Sigma.js + React Flow; egui fallback; ratatui companion) sized to visualise 10k+-node harness graphs.

## What this PR contains

- `docs/proposals/v3-harness-manager.md` — 288-line proposal with §10 go/no-go questionnaire.

## Test plan

- [x] No code; documentation only.
- [ ] Reviewer answers §10 questionnaire.
- [ ] Follow-up PR: \`docs/harness-manager-plan.md\` (FR-numbered execution plan) + begin S1 (enumerate + categorise).

## Supporting research

Three parallel deep-research agents covered SoA, relation taxonomy, and GUI stack. Full URL bibliographies kept in the agent transcripts under \`.claude/projects/.../tasks/\`.