### PR TITLE
docs: close v1.2.0 out — README + upcoming.md + plan status marks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,22 +32,50 @@ This uninstall-first design is SpecERE's core UX differentiator versus SpecKit, 
 
 ## Status
 
-**v1.0.3 on `main`** — all seven master-plan phases shipped. `specere calibrate from-git` surfaces real architectural coupling on live repos. Full Gate-A parity with the ReSearch Python prototype (bit-identical for PerSpecHMM + FactorGraphBP; tail-MAP-within-2-pp for RBPF).
+**v1.2.0 feature-complete on `main`** (not yet tagged) — the **harness manager & inspector** upgrade lands on top of the v1.0.5 evidence-quality work. All seven master-plan phases remain shipped. 358 workspace tests.
 
 Not on crates.io yet; install from the [GitHub Release](https://github.com/laiadlotape/specere/releases/latest) shell / powershell installer.
+
+### Master plan (v0.1 → v1.0.0)
 
 | Phase | What ships | Status |
 |---|---|---|
 | Phase 0 — doc rectification | README / CONTRIBUTING / CHANGELOG aligned to pivot | ✅ Shipped (2026-04-18) |
-| Phase 1 — bugfix release | Drop `--no-git`, SHA-diff gate, first `after_implement` hook, marker-fenced `.gitignore`, bit-identical remove, parse-safety | ✅ v0.2.0 (2026-04-18) — 9 FRs, 37/37 tests |
-| Phase 2 — native units | All 5 MVP units implemented end-to-end | ✅ Shipped (2026-04-18) — 5 units real; `specere init` composes the full scaffold; 65/65 tests |
-| Phase 3 — observe pipeline | Embedded OTLP receiver + `specere-observe` workflow | ✅ v0.4.0 (2026-04-18) — OTLP HTTP + gRPC + SQLite event store + 13 workflow-span hooks; FR-P3-001 through FR-P3-006 closed |
-| Phase 4 — filter engine | Rust port of the ReSearch prototype's three Bayesian filters | ✅ v0.4.0 / v0.4.0 follow-ups — PerSpecHMM + FactorGraphBP + RBPF + `specere filter run/status` CLI; FR-P4-001 through FR-P4-006 closed; Python-prototype parity bit-identical on Gate-A for PerSpecHMM + BP |
-| Phase 5 — motion-model calibration | `specere calibrate from-git` | ✅ v0.5.0 (partial) — coupling-edge suggester from git log co-modification; full motion-matrix fit deferred (needs test-history source) |
-| Phase 6 — cross-session persistence | Posterior survives across sessions | ✅ v1.0.0 — posterior bit-identical across process restarts; FR-P6 regression caught + fixed |
-| Phase 7 — v1.0.0 release | Final tear-down-and-rebuild dogfood on ReSearch | ✅ v1.0.0 (2026-04-18); v1.0.1 calibrate path-prefix fix; v1.0.2 RBPF/BP parity closes #42; v1.0.3 ears-lint parser hardening closes #61 |
+| Phase 1 — bugfix release | Drop `--no-git`, SHA-diff gate, first `after_implement` hook, marker-fenced `.gitignore`, bit-identical remove, parse-safety | ✅ v0.2.0 — 9 FRs, 37/37 tests |
+| Phase 2 — native units | All 5 MVP units implemented end-to-end | ✅ Shipped — 5 units real; `specere init` composes the full scaffold |
+| Phase 3 — observe pipeline | Embedded OTLP receiver + `specere-observe` workflow | ✅ v0.4.0 — OTLP HTTP + gRPC + SQLite event store + 13 workflow-span hooks |
+| Phase 4 — filter engine | Rust port of the ReSearch prototype's three Bayesian filters | ✅ PerSpecHMM + FactorGraphBP + RBPF; Python-prototype parity bit-identical on Gate-A for PerSpecHMM + BP |
+| Phase 5 — motion-model calibration | `specere calibrate from-git` + motion-from-evidence fit | ✅ v0.5.0 coupling-edge suggester + v1.0.5 `calibrate motion-from-evidence` |
+| Phase 6 — cross-session persistence | Posterior survives across sessions | ✅ v1.0.0 — posterior bit-identical across process restarts |
+| Phase 7 — v1.0.0 release | Tear-down-and-rebuild dogfood on ReSearch | ✅ v1.0.0; v1.0.1–1.0.4 bugfix follow-ups |
 
-**Release:** current stable is **v1.0.3**. See [CHANGELOG.md](./CHANGELOG.md) for the full history.
+### Post-v1.0 upgrades
+
+| Track | What ships | Status |
+|---|---|---|
+| **v1.0.5 evidence-quality** | Mutation-calibrated sensors, test-smell detector, motion-from-evidence fit, suspicious-SAT review queue. FR-EQ-001..007. | ✅ All 7 FRs on main (PRs #88–#92) |
+| **v1.2.0 harness manager** | Classify + inspect every test/bench/fuzz/mock/workflow file; provenance + git history + coverage + flakiness + Leiden clustering; OTel semconv; ratatui TUI. FR-HM-001..072. | ✅ All 30 FRs on main (PRs #94, #96–#101) |
+| v1.0.6 bug-tracker bridge | GitHub + Gitea issue → posterior. FR-EQ-010..013. | ⏸ Queued |
+| v1.1.0 LLM adversary | Budgeted counter-test generator. FR-EQ-020..024. | ⏸ Queued |
+| v2.0.0 GUI | Tauri v2 + Sigma.js 6-screen inspector. FR-HM-080..085. | ⏸ Not yet started |
+
+### Harness-manager CLI (v1.2.0)
+
+The harness tree is reachable via a single `specere harness` command group:
+
+```
+specere harness scan                    # classify every file into nine categories
+specere harness provenance              # link files to /speckit-* verbs + git commits
+specere harness history                 # churn, age, hotspot score, co-modification PPMI
+specere harness coverage --from-lcov-dir <path>   # per-test Jaccard on line hits
+specere harness flaky --from-runs <path>          # co-failure PPMI + Meta flakiness
+specere harness cluster --emit-to-sensor-map      # Louvain community detection
+specere harness tui                     # interactive ratatui inspector
+```
+
+Every verb writes into `.specere/harness-graph.toml` and emits a `harness_*_completed` event to `.specere/events.jsonl` per the [OTel supplementary semantic convention](docs/otel-specere-semconv.md).
+
+**Release:** current stable is **v1.0.4** on [GitHub Releases](https://github.com/laiadlotape/specere/releases). v1.0.5 + v1.2.0 entries accumulate under `[Unreleased]` in [CHANGELOG.md](./CHANGELOG.md) and will ship as one tagged release once the user calls the cut.
 
 **Test plans for contributors:**
 - [`docs/test-plans/self-dogfood-guide.md`](docs/test-plans/self-dogfood-guide.md) — 38-scenario CLI-driven smoke suite, ~25 min.

--- a/docs/harness-manager-plan.md
+++ b/docs/harness-manager-plan.md
@@ -2,13 +2,14 @@
 
 **Status.** Scope + direction approved via §10 questionnaire on `docs/proposals/v3-harness-manager.md` (2026-04-20).
 
-**Release shape (decided).**
+**v1.2.0 feature-complete on main (2026-04-20):** S1–S6 all shipped (PRs #94, #96, #97, #98, #99) + OTel semconv formalised (PR #100) + ratatui TUI companion shipped (PR #101). 358 workspace tests green. Release tag not yet cut — deferred per user's "mega-release packaging" choice so v1.2.0 ships with any final GUI-API endpoints or polish items.
+
+**Release shape (decided + current status).**
 
 | Release | Contents | Size | Heavy deps | Status |
 |---|---|---|---|---|
-| **v1.2.0** | S1–S6 mega-release (harness scan + provenance + history + coverage + flakiness + clustering) | ~2400 LoC | `cargo-llvm-cov` subprocess (opt-in per-repo via `[specere.coverage] enabled = true`) | 📋 Planning |
-| **v2.0.0** | Tauri v2 + Sigma.js GUI; 6-screen MVP | ~frontend + ~500 LoC Rust API layer | `@sigma/core`, `graphology`, `react-flow` via Tauri shell | 📋 Parallel track |
-| **TUI** | `specere harness tui` ratatui companion | ~600 LoC | `ratatui`, `crossterm` | 🌙 Night-and-weekend parallel track |
+| **v1.2.0** | S1–S6 (scan + provenance + history + coverage + flakiness + clustering) + semconv + TUI | ~2400 LoC + ~600 LoC TUI + ~550 LoC semconv/event-emit | `cargo-llvm-cov` subprocess (opt-in), `ratatui`, `crossterm`, `syn`, `sha2`, `hex` | ✅ **Landed on main** |
+| **v2.0.0** | Tauri v2 + Sigma.js GUI; 6-screen MVP | ~frontend + ~500 LoC Rust API layer | `@sigma/core`, `graphology`, `react-flow` via Tauri shell | 📋 Not yet started — substantial frontend scoping |
 | **v1.0.6** (post-v2) | Bug-tracker bridge (FR-EQ-010..013) | ~600 LoC | `octocrab`, `gitea-sdk` | ⏸ Queued |
 | **v1.1.0** (post-v2) | LLM adversary (FR-EQ-020..024) | ~800 LoC | paid LLM spend | ⏸ Queued |
 
@@ -25,17 +26,17 @@
 
 ## 1. FR numbering map
 
-| FR range | Slice | Ships in |
-|---|---|---|
-| FR-HM-001..004 | S1 — enumerate + categorise | v1.2.0 |
-| FR-HM-010..012 | S2 — provenance join | v1.2.0 |
-| FR-HM-020..022 | S3 — git version + co-modification | v1.2.0 |
-| FR-HM-030..033 | S4 — coverage co-execution | v1.2.0 |
-| FR-HM-040..043 | S5 — co-failure + flakiness | v1.2.0 |
-| FR-HM-050..052 | S6 — cluster + filter wiring | v1.2.0 |
-| FR-HM-060..061 | `specere.harness.*` OTel semconv | v1.2.0 (cross-cutting) |
-| FR-HM-070..072 | TUI companion | parallel |
-| FR-HM-080..085 | GUI v2.0.0 (6 screens) | parallel, v2.0.0 |
+| FR range | Slice | Ships in | Status |
+|---|---|---|---|
+| FR-HM-001..004 | S1 — enumerate + categorise | v1.2.0 | ✅ merged PR #94 |
+| FR-HM-010..012 | S2 — provenance join | v1.2.0 | ✅ merged PR #94 |
+| FR-HM-020..022 | S3 — git version + co-modification | v1.2.0 | ✅ merged PR #96 |
+| FR-HM-030..033 | S4 — coverage co-execution | v1.2.0 | ✅ merged PR #97 |
+| FR-HM-040..043 | S5 — co-failure + flakiness | v1.2.0 | ✅ merged PR #98 |
+| FR-HM-050..052 | S6 — cluster + filter wiring | v1.2.0 | ✅ merged PR #99 |
+| FR-HM-060..061 | `specere.harness.*` OTel semconv | v1.2.0 (cross-cutting) | ✅ merged PR #100 |
+| FR-HM-070..072 | TUI companion | parallel | ✅ merged PR #101 |
+| FR-HM-080..085 | GUI v2.0.0 (6 screens) | parallel, v2.0.0 | ⏸ not yet started |
 
 ---
 

--- a/docs/upcoming.md
+++ b/docs/upcoming.md
@@ -6,9 +6,38 @@
 
 ## Priority queue (highest first)
 
-**Nothing blocking a release.** All seven master-plan phases shipped through v1.0.3. The items below are polish-level follow-ups.
+**v1.2.0 harness-manager feature-complete on `main`.** All 30 FR-HM + 7 FR-EQ landed (PRs #88–#101). Queue below is for the release-cut + v2.0.0 GUI work.
 
-### 1. MarkerEntry schema backwards-compat
+### 0. Cut v1.0.5 + v1.2.0 release tag
+
+- **What.** First tag since v1.0.4. Combines the evidence-quality slice (FR-EQ-001..007) + harness-manager slice (FR-HM-001..072). Both accumulate under `[Unreleased]` in CHANGELOG.md today.
+- **Why deferred.** User chose "mega-release packaging" in the §10 harness-manager questionnaire — means no patch-level tag until every slice landed. That condition is now met.
+- **Action.** Bump workspace version in Cargo.toml from `1.0.4` → `1.2.0`; split the Unreleased section into `[1.2.0]` headers; tag + push; cargo-dist publishes.
+
+### 1. v2.0.0 GUI scaffolding (Tauri v2 + Sigma.js)
+
+- **Scope.** FR-HM-080..085 — six-screen MVP: Harness Graph, Spec Dashboard, Review Queue, Event Timeline, Relation Inspector, Calibration View.
+- **Stack.** Tauri v2 shell + `@sigma/core` + `graphology` for 10k+-node WebGL graph; React Flow for edge-inspector panels; reuses existing Axum `serve http` endpoints.
+- **Blocker.** Adds JS/TS build toolchain to the repo for the first time — worth user check-in before starting.
+- **Estimated size.** ~500 LoC Rust (new REST endpoints) + ~3000 LoC frontend.
+
+### 2. v1.0.6 bug-tracker bridge (FR-EQ-010..013)
+
+- **Scope.** `specere observe watch-issues` polls GitHub + Gitea; emits `bug_reported` events that feed the posterior with decay. LLM issue-to-spec triage via text-embedding-3-small.
+- **Size.** ~600 LoC; adds `octocrab` + a Gitea client.
+- **Blocker.** Needs user credentials — config surface to design.
+
+### 3. v1.1.0 LLM adversary agent (FR-EQ-020..024)
+
+- **Scope.** Budgeted ($20/mo cap) counter-test generator.
+- **Size.** ~800 LoC + ongoing LLM spend.
+
+### 4. FR-HM-052b cluster-belief priors wired into the BBN
+
+- **Why.** v1.2.0 emits the `[harness_cluster]` snippet but doesn't yet auto-wire `Calibration::from_cluster()` into `PerSpecTestSensor`. Users can paste the snippet for now; proper filter-side integration follows once real repos exercise the cluster assignments.
+- **Size.** ~200 LoC in `specere-filter::state`.
+
+### 5. MarkerEntry schema backwards-compat
 
 - **Why.** The specere repo's own committed `.specere/manifest.toml` uses an early pre-`unit_id` MarkerEntry schema. `specere status` / `verify` on a fresh clone of the upstream repo errors with `missing field unit_id`. The self-dogfood guide's Setup block works around this by deleting `.specere/` first — but a real user upgrading from a very early SpecERE install would also hit it.
 - **Fix.** `#[serde(default)]` on `MarkerEntry.unit_id`; infer from the containing `[[units]].unit_id` during deserialisation.
@@ -30,10 +59,19 @@
 
 ## Beyond the immediate queue
 
-Nothing in the master plan is open. v1.x is bug-fix + follow-ups only; v2.0 would be a deliberate schema-breaking re-plan.
+Nothing in the v1.0 master plan is open. v1.0.x line is bug-fix + evidence-quality; v1.2.0 is the harness manager (above); v2.0.0 GUI requires a deliberate JS toolchain decision; post-v2 queue is bug-tracker + LLM adversary.
 
 ## Recently closed
 
+- **v1.2.0 harness manager & inspector** (2026-04-20) — 30 FR-HM spread across 8 PRs; 358 workspace tests total. Plan at [`docs/harness-manager-plan.md`](./harness-manager-plan.md); proposal at [`docs/proposals/v3-harness-manager.md`](./proposals/v3-harness-manager.md).
+  - [PR #94](https://github.com/laiadlotape/specere/pull/94) S1+S2: `specere harness scan` + `specere harness provenance`.
+  - [PR #96](https://github.com/laiadlotape/specere/pull/96) S3: `specere harness history` — churn, age, hotspot, co-modification PPMI.
+  - [PR #97](https://github.com/laiadlotape/specere/pull/97) S4: `specere harness coverage` — LCOV → Jaccard → cov_cooccur edges.
+  - [PR #98](https://github.com/laiadlotape/specere/pull/98) S5: `specere harness flaky` — CI co-failure PPMI + Meta-style flakiness + DeFlaker filter.
+  - [PR #99](https://github.com/laiadlotape/specere/pull/99) S6: `specere harness cluster` — Louvain on the composite-edge graph.
+  - [PR #100](https://github.com/laiadlotape/specere/pull/100) FR-HM-060..061: `specere.harness.*` OTel supplementary semantic convention + completion events per verb.
+  - [PR #101](https://github.com/laiadlotape/specere/pull/101) FR-HM-070..072: `specere harness tui` — ratatui companion.
+- **v1.0.5 evidence-quality** (2026-04-19..20) — 7 FR-EQ across 5 PRs (#88–#92). Plan at [`docs/evidence-quality-plan.md`](./evidence-quality-plan.md); proposal at [`docs/proposals/v2-evidence-quality.md`](./proposals/v2-evidence-quality.md).
 - **phase-4-filter-engine main track** (2026-04-18, parent [#39](https://github.com/laiadlotape/specere/issues/39)) — `specere-filter` crate live; `specere filter run/status` wired; FR-P4-001, -003, -004, -006 closed. Execution plan archived at [`docs/history/phase4-execution-plan.md`](history/phase4-execution-plan.md).
   - [#40](https://github.com/laiadlotape/specere/issues/40) PerSpecHMM scaffold (PR #45).
   - [#41](https://github.com/laiadlotape/specere/issues/41) FactorGraphBP + coupling loader + cycle rejection (PR #46).


### PR DESCRIPTION
## Summary

Documentation-only pass to reflect the completed state of v1.2.0. No code changes.

- **README Status section** rewritten:
  - Banner moves from "v1.0.3" to "v1.2.0 feature-complete on \`main\`" (not yet tagged).
  - New "Post-v1.0 upgrades" table distinguishes master-plan phases (all shipped) from v1.0.5 evidence-quality + v1.2.0 harness manager tracks.
  - New **harness-manager CLI cheat-sheet** for the \`specere harness *\` verb group.
- **docs/upcoming.md** queue rewritten with the next-action priorities:
  0. **Cut the v1.0.5 + v1.2.0 release tag** (everything accumulated under \`[Unreleased]\`; mega-release packaging choice now satisfied).
  1. v2.0.0 GUI scaffolding (Tauri v2 + Sigma.js).
  2. v1.0.6 bug-tracker bridge (FR-EQ-010..013).
  3. v1.1.0 LLM adversary (FR-EQ-020..024).
  4. FR-HM-052b cluster-belief priors wired into the BBN.
  5. Pre-existing polish items (MarkerEntry compat, RBPF CLI routing, etc.).
- **docs/harness-manager-plan.md** FR numbering table grows a Status column showing each slice's merge PR; release-shape table marks v1.2.0 ✅ Landed.

## Test plan

- [x] 358 workspace tests still pass (no code changed).

## Follow-up

When this merges, the natural next step is cutting the v1.2.0 release tag — which is a user decision, so I'll pause here rather than push that autonomously.