### PR TITLE
fix(manifest): backwards-compat for pre-v1.0 MarkerEntry unit_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to SpecERE will be documented here. The format follows [Keep
 
 ## [Unreleased]
 
+### Fixed (v1.2.0 prep — polish)
+
+- **Pre-v1.0 manifest backwards compatibility** (`docs/upcoming.md` §5). Old `.specere/manifest.toml` files (generated before v1.0) did not emit `unit_id` on each `MarkerEntry`, so loading them would crash with `missing field unit_id`. Fixed via `#[serde(default)]` on `MarkerEntry.unit_id` (accepts the field's absence without error) plus a backfill pass in `Manifest::load_or_init` that copies each marker's owning `UnitEntry.id` into its empty `unit_id`. Manifests saved by v1.0+ are unaffected — the backfill is a no-op on healthy data. 2 unit tests in `specere-manifest` verify old-schema load + round-trip preservation.
+
 ### Added (v1.2.0 prep — harness manager TUI companion)
 
 - **`specere harness tui` ratatui TUI companion** (FR-HM-070..072). Interactive terminal UI over `.specere/harness-graph.toml`. Three-pane layout: node list (filterable with `/`), detail pane (per-node provenance / coverage / flakiness / cluster metadata), event timeline footer (last few `harness_*_completed` spans). Relation-inspector modal on Enter shows 2-hop neighbourhood counts + incoming/outgoing direct-use edges. Keybindings: `j`/`k` navigate, `Tab` cycles focus, `Enter` opens inspector, `Esc` closes, `/` filters, `q` quits. Pure-data `TuiState` + `render` separation — unit-tested via ratatui's `TestBackend` without needing a real TTY. Hidden `--headless-frames N` flag paints N frames to a TestBackend and exits (CI smoke). 11 unit tests (state-machine transitions + render-without-panic + inspector-overlay-content) + 3 integration tests (CLI smoke with/without scan, events.jsonl footer). Adds `ratatui 0.28` + `crossterm 0.28` as workspace deps.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,6 +2145,7 @@ dependencies = [
  "serde",
  "sha2",
  "specere-core",
+ "tempfile",
  "thiserror 1.0.69",
  "time",
  "toml",

--- a/crates/specere-core/src/lib.rs
+++ b/crates/specere-core/src/lib.rs
@@ -162,6 +162,12 @@ pub struct FileEntry {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MarkerEntry {
     pub path: PathBuf,
+    /// Backwards-compat: pre-v1.0 manifests did not emit this field. The
+    /// manifest loader backfills from the containing `[[units]].id`
+    /// after deserialisation (see `specere_manifest::Manifest::load_or_init`).
+    /// We accept an empty string on wire to avoid a hard `missing field`
+    /// error on old manifests.
+    #[serde(default)]
     pub unit_id: String,
     pub block_id: Option<String>,
     pub sha256: String,

--- a/crates/specere-manifest/Cargo.toml
+++ b/crates/specere-manifest/Cargo.toml
@@ -18,3 +18,6 @@ hex.workspace = true
 thiserror.workspace = true
 time.workspace = true
 specere-core.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/specere-manifest/src/lib.rs
+++ b/crates/specere-manifest/src/lib.rs
@@ -59,13 +59,24 @@ impl Manifest {
     pub fn load_or_init(path: &Path, specere_version: &str) -> anyhow::Result<Self> {
         if path.exists() {
             let text = fs::read_to_string(path)?;
-            let m: Manifest = toml::from_str(&text)?;
+            let mut m: Manifest = toml::from_str(&text)?;
             if m.meta.schema_version != SCHEMA_VERSION {
                 anyhow::bail!(
                     "manifest schema version {} not supported (expected {})",
                     m.meta.schema_version,
                     SCHEMA_VERSION
                 );
+            }
+            // Backwards-compat: pre-v1.0 manifests did not emit `unit_id`
+            // on MarkerEntry. We deserialise with `#[serde(default)]` (so
+            // the field lands as empty string) and backfill here from the
+            // containing unit's id. See `docs/upcoming.md` §5.
+            for unit in &mut m.units {
+                for marker in &mut unit.markers {
+                    if marker.unit_id.is_empty() {
+                        marker.unit_id = unit.id.clone();
+                    }
+                }
             }
             Ok(m)
         } else {
@@ -143,4 +154,73 @@ fn now_rfc3339() -> String {
     time::OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Pre-v1.0 manifest shape: no `unit_id` on `MarkerEntry`. The loader
+    /// must accept the old schema without erroring and backfill each
+    /// marker's unit_id from the containing unit's id.
+    #[test]
+    fn load_backfills_marker_unit_id_from_parent_unit() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("manifest.toml");
+        fs::write(
+            &path,
+            r#"[meta]
+specere_version = "0.1.0"
+schema_version = 1
+created_at = "2026-04-18T00:00:00Z"
+
+[[units]]
+id = "speckit"
+version = "1.0"
+installed_at = "2026-04-18T00:00:00Z"
+
+[[units.markers]]
+path = ".gitignore"
+block_id = "speckit-block"
+sha256 = "deadbeef"
+"#,
+        )
+        .unwrap();
+        let m = Manifest::load_or_init(&path, "1.2.0").expect("old-schema manifest loads");
+        assert_eq!(m.units.len(), 1);
+        let u = &m.units[0];
+        assert_eq!(u.id, "speckit");
+        assert_eq!(u.markers.len(), 1);
+        // unit_id must be backfilled from parent `id`, not left empty.
+        assert_eq!(u.markers[0].unit_id, "speckit");
+    }
+
+    /// Round-trip: a manifest written by this version MUST deserialise
+    /// without the backfill being needed (so newer markers carry their
+    /// own unit_id on disk). Keeps the backfill a no-op on healthy data.
+    #[test]
+    fn round_trip_preserves_explicit_unit_id() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("manifest.toml");
+        let mut m = Manifest::new("1.2.0");
+        m.units.push(UnitEntry {
+            id: "filter-state".into(),
+            version: "1.0".into(),
+            installed_at: "2026-04-18T00:00:00Z".into(),
+            install_config: toml::Table::new(),
+            files: Vec::new(),
+            markers: vec![specere_core::MarkerEntry {
+                path: ".gitignore".into(),
+                unit_id: "filter-state".into(),
+                block_id: Some("filter-state-block".into()),
+                sha256: "abc123".into(),
+            }],
+            dirs: Vec::new(),
+            notes: Vec::new(),
+        });
+        m.save(&path).unwrap();
+        let loaded = Manifest::load_or_init(&path, "1.2.0").unwrap();
+        assert_eq!(loaded.units[0].markers[0].unit_id, "filter-state");
+    }
 }


### PR DESCRIPTION
## Summary

Small polish item from \`docs/upcoming.md\` §5.

Old \`.specere/manifest.toml\` files generated before v1.0 didn't include \`unit_id\` on each \`MarkerEntry\`. Loading them errored with \`missing field unit_id\`. This PR makes the loader tolerate the old schema.

### The fix

- \`#[serde(default)]\` on \`MarkerEntry.unit_id\` — accepts the field's absence without error (deserialises to empty string).
- Backfill pass in \`Manifest::load_or_init\` copies each marker's owning \`UnitEntry.id\` into any empty \`unit_id\`.

Manifests written by v1.0+ carry \`unit_id\` explicitly — the backfill is a no-op on healthy data.

## Test plan

- [x] \`load_backfills_marker_unit_id_from_parent_unit\` — loads a pre-v1.0 manifest fixture, asserts \`unit_id\` is backfilled from the parent unit.
- [x] \`round_trip_preserves_explicit_unit_id\` — saves a v1.0+ manifest, loads it, asserts the explicit \`unit_id\` round-trips unchanged.
- [x] 360 workspace tests pass (was 358 — +2 from this PR).
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.

## Plan reference

\`docs/upcoming.md\` §5. Closes the \"MarkerEntry schema backwards-compat\" polish item.