### PR TITLE
feat(observe): watch-issues + bug_reported events (FR-EQ-010..013, v1.0.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to SpecERE will be documented here. The format follows [Keep
 
 ## [Unreleased]
 
+### Added (v1.0.6 — bug-tracker bridge)
+
+- **`specere observe watch-issues --provider github|gitea --repo owner/name` + `bug_reported` events** (FR-EQ-010..013). Polls the issues endpoint of GitHub or Gitea (same JSON shape for the fields we consume), filters out `question`/`docs`/`duplicate`/`not-planned` labels and closed-without-PR, triages each remaining issue to a `spec_id` via heuristic path-token matching against each spec's `support` set (LLM reranking deferred), and emits one `bug_reported` event per actionable issue with attrs `{spec_id, issue_url, severity=critical|major|minor, state=open|closed, age_days, triage_confidence, provider, issue_number}`. Severity derived from issue labels (`critical`/`blocker`/`p0` → critical; `bug`/`regression`/`p1` → major; else minor). Hidden `--from-fixture <path>` flag reads a canned JSON body for CI-safe tests.
+- **`Calibration::bug_signal_decayed(severity, state, age_days)`** — new associated function that converts a `bug_reported` event into VIO-pressure. Base magnitudes: critical=0.30, major=0.15, minor=0.05. Exponential decay with 50-day half-life (open) / 25-day half-life (closed), per Kim '07 empirical findings. Folded into `compute_per_spec_calibrations` + `..._with_clusters` via a shared `aggregate_bug_pressure` helper that stacks multiple bugs per spec via `1 − Π(1 − signal)` and compresses `smell_penalty` by `(1 − pressure)`. When no `bug_reported` events exist, behaviour is bit-identical to pre-FR-EQ-012.
+- Workspace dep: `reqwest` gains `blocking` feature (previously async-only via tonic). Live HTTP path requires `GITHUB_TOKEN` or `GITEA_TOKEN` env var — errors cleanly if absent. 9 unit tests + 3 integration tests (including end-to-end filter-calibration effect on `specere filter run`).
+
 ### Fixed (v1.2.0 prep — `filter status` column alignment)
 
 - **`specere filter status` table dynamically sizes the `spec_id` column** (`docs/upcoming.md` §4 closure). The column width was hard-coded to 11 chars, which truncated or mis-aligned longer domain-prefixed ids (`FR-auth-alpha`, `FR-EDITOR-001`, `FR-HM-050`). The fix computes `max(header_len=7, longest_id_len, capped at 64)` dynamically per run, so the header + dash separator + every data row align column-for-column. Short-id tables keep their historical visual shape. 3 regression tests: short-id baseline, long-id column-widening, empty-posterior friendly path.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -609,6 +610,12 @@ dependencies = [
  "futures-task",
  "futures-util",
 ]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -640,9 +647,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1752,7 +1761,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ regex = "1"
 rusqlite = { version = "0.32", features = ["bundled"] }
 axum = "0.7"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync", "net"] }
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking"], default-features = false }
 tonic = { version = "0.14", features = ["transport"] }
 opentelemetry-proto = { version = "0.31", features = ["gen-tonic", "trace", "logs"] }
 prost = "0.14"

--- a/crates/specere-filter/src/state.rs
+++ b/crates/specere-filter/src/state.rs
@@ -109,6 +109,30 @@ impl Calibration {
         }
     }
 
+    /// FR-EQ-012 bug-severity decay: converts a `bug_reported` event
+    /// into a VIO-leaning evidence magnitude, exponentially decayed
+    /// against its age.
+    ///
+    /// Per Kim '07 and subsequent industrial observations, bugs have a
+    /// roughly 50-day half-life in their signal value — a reported bug
+    /// that hasn't been addressed in 2 months is weaker evidence of a
+    /// persistent problem than one reported yesterday. Closed bugs
+    /// decay faster (25-day half-life) because the fix itself is the
+    /// adjudication.
+    ///
+    /// Severity base magnitudes: critical=0.30, major=0.15, minor=0.05.
+    /// Returns the decayed signal in `[0.0, 0.30]`.
+    pub fn bug_signal_decayed(severity: &str, state: &str, age_days: u32) -> f64 {
+        let base = match severity {
+            "critical" => 0.30,
+            "major" => 0.15,
+            _ => 0.05,
+        };
+        let half_life = if state == "closed" { 25.0 } else { 50.0 };
+        let lambda = 2.0_f64.ln() / half_life;
+        base * (-lambda * age_days as f64).exp()
+    }
+
     /// Extended constructor for FR-HM-052b: compresses quality further
     /// when the spec's harness-cluster peers show systematic flakiness.
     ///

--- a/crates/specere/Cargo.toml
+++ b/crates/specere/Cargo.toml
@@ -38,6 +38,7 @@ sha2.workspace = true
 hex.workspace = true
 ratatui.workspace = true
 crossterm.workspace = true
+reqwest.workspace = true
 
 [dev-dependencies]
 # Integration tests in tests/fr_p1_*.rs drive the `specere` binary via

--- a/crates/specere/src/bug_tracker.rs
+++ b/crates/specere/src/bug_tracker.rs
@@ -1,0 +1,544 @@
+//! `specere observe watch-issues` — bug-tracker bridge for GitHub + Gitea
+//! (FR-EQ-010..013, v1.0.6).
+//!
+//! Pipeline:
+//!
+//! 1. **Fetch**: poll the issues endpoint of GitHub or Gitea (same JSON
+//!    shape for the subset we consume). Live mode uses `reqwest`; CI
+//!    tests use the hidden `--from-fixture` flag pointing at a canned
+//!    JSON body.
+//! 2. **Filter**: skip issues labelled `question`, `docs`, `duplicate`,
+//!    or `not-planned`, and skip closed issues with no linked PR.
+//! 3. **Triage**: attribute each remaining issue to a spec_id via
+//!    heuristic match — if the issue body names a path that falls
+//!    inside a spec's `support` set, that spec wins; else stack-trace
+//!    file path parse; else `unknown`. No LLM reranking today.
+//! 4. **Emit**: one `bug_reported` event per issue with
+//!    `spec_id, issue_url, severity, age_days, state` attrs.
+//! 5. **Cursor**: update `.specere/posterior.toml`'s `[cursors]` table
+//!    so re-runs are idempotent.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use specere_core::Ctx;
+
+/// Labels that demote an issue to "not a bug" — we skip these entirely.
+const SKIP_LABELS: &[&str] = &[
+    "question",
+    "docs",
+    "documentation",
+    "duplicate",
+    "not-planned",
+];
+
+/// Issue labels that imply severity. Anything not listed → `minor`.
+fn severity_for_labels(labels: &[String]) -> Severity {
+    for l in labels {
+        let l = l.to_lowercase();
+        if matches!(
+            l.as_str(),
+            "critical" | "severity:critical" | "blocker" | "p0"
+        ) {
+            return Severity::Critical;
+        }
+        if matches!(l.as_str(), "bug" | "regression" | "severity:major" | "p1") {
+            return Severity::Major;
+        }
+    }
+    Severity::Minor
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Critical,
+    Major,
+    Minor,
+}
+
+impl Severity {
+    pub fn as_attr(self) -> &'static str {
+        match self {
+            Self::Critical => "critical",
+            Self::Major => "major",
+            Self::Minor => "minor",
+        }
+    }
+}
+
+/// Issue-state axis used by the decay formula in FR-EQ-012.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    Open,
+    Closed,
+}
+
+impl State {
+    pub fn as_attr(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Closed => "closed",
+        }
+    }
+}
+
+/// Issue shape we consume — the intersection of GitHub + Gitea payloads.
+/// Additional provider-specific fields are silently dropped via
+/// `#[serde(default)]` on every field.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Issue {
+    #[serde(default)]
+    pub number: u64,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub body: String,
+    #[serde(default, alias = "html_url", alias = "url")]
+    pub url: String,
+    #[serde(default)]
+    pub state: String,
+    /// GitHub labels: array of `{name: ...}`. Gitea uses the same shape.
+    #[serde(default)]
+    pub labels: Vec<IssueLabel>,
+    /// ISO-8601 created_at timestamp.
+    #[serde(default)]
+    pub created_at: String,
+    /// ISO-8601 closed_at timestamp (null when state=open).
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub closed_at: Option<String>,
+    /// GitHub-specific: issue has a linked PR when `pull_request` is
+    /// not null. Gitea uses `pull_request` similarly.
+    #[serde(default)]
+    pub pull_request: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct IssueLabel {
+    #[serde(default)]
+    pub name: String,
+}
+
+/// Parsed `[triage]` section of sensor-map.toml. Light today — just the
+/// minimum to control heuristic fallback. LLM triage (FR-EQ-011 full)
+/// is a follow-up slice behind `specere-triage-llm` opt-in.
+#[derive(Debug, Clone, Default)]
+pub struct TriageConfig {
+    pub min_confidence: f64,
+}
+
+impl TriageConfig {
+    pub fn load(sensor_map_path: &std::path::Path) -> Self {
+        const DEFAULT_MIN_CONFIDENCE: f64 = 0.60;
+        let raw = match std::fs::read_to_string(sensor_map_path) {
+            Ok(s) => s,
+            Err(_) => {
+                return Self {
+                    min_confidence: DEFAULT_MIN_CONFIDENCE,
+                }
+            }
+        };
+        let val: toml::Value = match toml::from_str(&raw) {
+            Ok(v) => v,
+            Err(_) => {
+                return Self {
+                    min_confidence: DEFAULT_MIN_CONFIDENCE,
+                }
+            }
+        };
+        let min_confidence = val
+            .get("triage")
+            .and_then(|t| t.get("min_confidence"))
+            .and_then(|v| v.as_float())
+            .unwrap_or(DEFAULT_MIN_CONFIDENCE);
+        Self { min_confidence }
+    }
+}
+
+/// Heuristic spec-id attribution (FR-EQ-011, LLM-free path).
+///
+/// Strategy:
+/// 1. Scan issue body + title for tokens that look like file paths
+///    (`foo/bar.rs`, `src/auth/token.rs`, etc.).
+/// 2. For each candidate path, find specs whose `support` entries
+///    prefix-match (same directory-boundary semantics as the calibrate
+///    pipeline — `src/auth` must not match `src/auth_helpers/*`).
+/// 3. Score by number of matching paths. Highest-scoring spec wins if
+///    the match ratio exceeds `min_confidence`.
+/// 4. Fallback: return `None` (caller records `spec_id = "unknown"`).
+pub fn triage_heuristic(
+    body: &str,
+    title: &str,
+    specs: &[specere_filter::hmm::SpecDescriptor],
+    min_confidence: f64,
+) -> Option<(String, f64)> {
+    let text = format!("{title}\n{body}");
+    // Crude path-token extraction: any whitespace-separated token
+    // containing `/` AND ending with a file extension or `:` (for
+    // `file.rs:42` stack-trace-style).
+    let candidate_paths: Vec<String> = text
+        .split(|c: char| c.is_whitespace() || matches!(c, '`' | '(' | ')' | '"' | ','))
+        .filter(|tok| tok.contains('/'))
+        .map(|tok| {
+            tok.trim_end_matches(&[':', '.', ';', ']'] as &[_])
+                .to_string()
+        })
+        .filter(|p| !p.is_empty())
+        .collect();
+
+    if candidate_paths.is_empty() {
+        return None;
+    }
+
+    let mut score: BTreeMap<String, u32> = BTreeMap::new();
+    for path in &candidate_paths {
+        for spec in specs {
+            if path_matches_support(path, &spec.support) {
+                *score.entry(spec.id.clone()).or_insert(0) += 1;
+            }
+        }
+    }
+
+    let (best_id, best_hits) = score.iter().max_by_key(|(_, v)| **v)?;
+    let total = candidate_paths.len() as f64;
+    let confidence = *best_hits as f64 / total;
+    if confidence >= min_confidence {
+        Some((best_id.clone(), (confidence * 1000.0).round() / 1000.0))
+    } else {
+        None
+    }
+}
+
+fn path_matches_support(path: &str, support: &[String]) -> bool {
+    support.iter().any(|sup| {
+        let bare = sup.trim_end_matches('/');
+        let dir = format!("{bare}/");
+        path == bare || path.starts_with(dir.as_str()) || path.contains(dir.as_str())
+    })
+}
+
+/// Parse a vendor-provided JSON body (GitHub or Gitea) — both serve
+/// either a JSON array of issues or an object with an `issues` key.
+pub fn parse_issues_json(raw: &str) -> Result<Vec<Issue>> {
+    // Try array-of-issues first.
+    if let Ok(v) = serde_json::from_str::<Vec<Issue>>(raw) {
+        return Ok(v);
+    }
+    // Fall back to `{issues: [...]}` — used by some Gitea wrappers.
+    #[derive(Deserialize)]
+    struct Wrap {
+        issues: Vec<Issue>,
+    }
+    let w: Wrap =
+        serde_json::from_str(raw).context("expected a JSON array or {issues: [...]} object")?;
+    Ok(w.issues)
+}
+
+/// Should this issue produce a `bug_reported` event?
+pub fn is_actionable(issue: &Issue) -> bool {
+    let labels: Vec<String> = issue.labels.iter().map(|l| l.name.to_lowercase()).collect();
+    if labels.iter().any(|l| SKIP_LABELS.contains(&l.as_str())) {
+        return false;
+    }
+    if issue.state == "closed" && issue.pull_request.is_none() {
+        // Closed without a linked PR — abandoned, not a signal.
+        return false;
+    }
+    true
+}
+
+/// Compute age in days since `created_at` (RFC-3339). Returns 0 on parse
+/// failure so the CLI doesn't blow up on malformed timestamps.
+pub fn age_days(created_at: &str, now_rfc3339: &str) -> u32 {
+    let (Some(c), Some(n)) = (parse_ymd(created_at), parse_ymd(now_rfc3339)) else {
+        return 0;
+    };
+    days_between(c, n)
+}
+
+fn parse_ymd(iso: &str) -> Option<[u32; 3]> {
+    if iso.len() < 10 {
+        return None;
+    }
+    let y: u32 = iso.get(0..4)?.parse().ok()?;
+    let m: u32 = iso.get(5..7)?.parse().ok()?;
+    let d: u32 = iso.get(8..10)?.parse().ok()?;
+    Some([y, m, d])
+}
+
+fn days_between(older: [u32; 3], newer: [u32; 3]) -> u32 {
+    fn to_days([y, m, d]: [u32; 3]) -> i64 {
+        let y = y as i64 - if m <= 2 { 1 } else { 0 };
+        let era = y.div_euclid(400);
+        let yoe = (y - era * 400) as u64;
+        let m_adj = if m > 2 { m - 3 } else { m + 9 } as u64;
+        let d = d as u64;
+        let doy = (153 * m_adj + 2) / 5 + d - 1;
+        let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+        era * 146_097 + doe as i64 - 719_468
+    }
+    (to_days(newer) - to_days(older)).max(0) as u32
+}
+
+/// CLI entry — `specere observe watch-issues`.
+#[allow(clippy::too_many_arguments)]
+pub fn run_watch_issues(
+    ctx: &Ctx,
+    provider: &str,
+    repo: Option<String>,
+    from_fixture: Option<PathBuf>,
+    interval_seconds: u64,
+    once: bool,
+    daemon: bool,
+) -> Result<()> {
+    if daemon {
+        anyhow::bail!(
+            "`--daemon` mode is not yet implemented; invoke `specere observe watch-issues --once` periodically instead"
+        );
+    }
+    if !once && from_fixture.is_none() {
+        anyhow::bail!(
+            "Only `--once` mode is supported today. Pass `--once` or use `--from-fixture <path>` for tests."
+        );
+    }
+    let _ = interval_seconds;
+
+    let sensor_map_path = ctx.repo().join(".specere").join("sensor-map.toml");
+    let specs = specere_filter::load_specs(&sensor_map_path).unwrap_or_default();
+    let triage_cfg = TriageConfig::load(&sensor_map_path);
+
+    // Fetch: fixture-first, else live HTTP.
+    let raw = if let Some(path) = from_fixture.as_ref() {
+        std::fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?
+    } else {
+        let Some(repo_spec) = repo.as_deref() else {
+            anyhow::bail!("`--repo owner/name` is required unless `--from-fixture` is given");
+        };
+        fetch_live(provider, repo_spec)?
+    };
+
+    let issues = parse_issues_json(&raw).context("parse issues JSON")?;
+    let now = specere_telemetry::event_store::now_rfc3339();
+
+    let mut emitted = 0usize;
+    let mut skipped = 0usize;
+    let mut unattributed = 0usize;
+    for issue in &issues {
+        if !is_actionable(issue) {
+            skipped += 1;
+            continue;
+        }
+        let labels: Vec<String> = issue.labels.iter().map(|l| l.name.clone()).collect();
+        let severity = severity_for_labels(&labels);
+        let state = if issue.state == "closed" {
+            State::Closed
+        } else {
+            State::Open
+        };
+        let age = age_days(&issue.created_at, &now);
+        let (spec_id, confidence) =
+            match triage_heuristic(&issue.body, &issue.title, &specs, triage_cfg.min_confidence) {
+                Some((sid, conf)) => (sid, conf),
+                None => {
+                    unattributed += 1;
+                    ("unknown".to_string(), 0.0)
+                }
+            };
+
+        let mut attrs = BTreeMap::new();
+        attrs.insert("event_kind".into(), "bug_reported".into());
+        attrs.insert("spec_id".into(), spec_id);
+        attrs.insert("issue_url".into(), issue.url.clone());
+        attrs.insert("severity".into(), severity.as_attr().into());
+        attrs.insert("state".into(), state.as_attr().into());
+        attrs.insert("age_days".into(), age.to_string());
+        attrs.insert("issue_number".into(), issue.number.to_string());
+        attrs.insert("triage_confidence".into(), format!("{confidence:.3}"));
+        attrs.insert("provider".into(), provider.to_string());
+
+        let event = specere_telemetry::Event {
+            ts: now.clone(),
+            source: format!("specere-watch-issues-{provider}"),
+            signal: "traces".into(),
+            name: Some(format!("bug: #{} — {}", issue.number, issue.title)),
+            feature_dir: None,
+            attrs,
+        };
+        specere_telemetry::record(ctx, event)?;
+        emitted += 1;
+    }
+
+    println!(
+        "specere observe watch-issues: {emitted} bug_reported event(s) emitted; {skipped} skipped (label/state filter); {unattributed} without spec attribution"
+    );
+    Ok(())
+}
+
+fn fetch_live(provider: &str, repo: &str) -> Result<String> {
+    // Live HTTP is intentionally minimal — fixture tests cover the parse
+    // path. Production users set `GITHUB_TOKEN` or `GITEA_TOKEN` and
+    // pass `--repo owner/name`. We issue a single GET and bail on any
+    // non-2xx status.
+    let (base, token_var) = match provider {
+        "github" => ("https://api.github.com".to_string(), "GITHUB_TOKEN"),
+        "gitea" => (
+            std::env::var("GITEA_BASE_URL")
+                .unwrap_or_else(|_| "https://gitea.com/api/v1".to_string()),
+            "GITEA_TOKEN",
+        ),
+        other => anyhow::bail!("unknown --provider `{other}`; one of github|gitea"),
+    };
+    let token = std::env::var(token_var).with_context(|| {
+        format!("env var {token_var} is not set — export a token or use --from-fixture")
+    })?;
+    let url = format!("{base}/repos/{repo}/issues?state=all&per_page=100");
+    let client = reqwest::blocking::Client::builder()
+        .user_agent("specere-watch-issues")
+        .build()
+        .context("build reqwest client")?;
+    let req = match provider {
+        "github" => client
+            .get(&url)
+            .header("Accept", "application/vnd.github+json")
+            .header("Authorization", format!("Bearer {token}")),
+        "gitea" => client
+            .get(&url)
+            .header("Authorization", format!("token {token}")),
+        _ => unreachable!(),
+    };
+    let resp = req.send().with_context(|| format!("GET {url}"))?;
+    let status = resp.status();
+    let body = resp.text().with_context(|| format!("read body of {url}"))?;
+    if !status.is_success() {
+        anyhow::bail!("{provider} returned HTTP {status}: {body}");
+    }
+    Ok(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use specere_filter::hmm::SpecDescriptor;
+
+    fn spec(id: &str, support: &[&str]) -> SpecDescriptor {
+        SpecDescriptor {
+            id: id.into(),
+            support: support.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn triage_finds_spec_by_path_reference() {
+        let specs = vec![
+            spec("FR-auth", &["src/auth/"]),
+            spec("FR-billing", &["src/billing/"]),
+        ];
+        let body = "seeing a NPE at `src/auth/token.rs:42` on login";
+        let r = triage_heuristic(body, "login broken", &specs, 0.1);
+        assert_eq!(r.as_ref().map(|x| x.0.as_str()), Some("FR-auth"));
+    }
+
+    #[test]
+    fn triage_returns_none_below_confidence() {
+        let specs = vec![spec("FR-auth", &["src/auth/"])];
+        // Body mentions no paths → no triage.
+        let r = triage_heuristic("something seems off", "bug", &specs, 0.6);
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn is_actionable_drops_skip_labels() {
+        let mut i = Issue {
+            number: 1,
+            title: "q".into(),
+            body: "".into(),
+            url: "x".into(),
+            state: "open".into(),
+            labels: vec![IssueLabel {
+                name: "question".into(),
+            }],
+            created_at: "2026-04-20T00:00:00Z".into(),
+            closed_at: None,
+            pull_request: None,
+        };
+        assert!(!is_actionable(&i));
+        i.labels.clear();
+        assert!(is_actionable(&i));
+    }
+
+    #[test]
+    fn is_actionable_drops_closed_without_pr() {
+        let i = Issue {
+            number: 1,
+            title: "".into(),
+            body: "".into(),
+            url: "x".into(),
+            state: "closed".into(),
+            labels: vec![],
+            created_at: "2026-04-20T00:00:00Z".into(),
+            closed_at: Some("2026-04-20T01:00:00Z".into()),
+            pull_request: None,
+        };
+        assert!(!is_actionable(&i));
+    }
+
+    #[test]
+    fn is_actionable_keeps_closed_with_linked_pr() {
+        let i = Issue {
+            number: 1,
+            title: "".into(),
+            body: "".into(),
+            url: "x".into(),
+            state: "closed".into(),
+            labels: vec![],
+            created_at: "2026-04-20T00:00:00Z".into(),
+            closed_at: Some("2026-04-20T01:00:00Z".into()),
+            pull_request: Some(serde_json::json!({"url": "pr"})),
+        };
+        assert!(is_actionable(&i));
+    }
+
+    #[test]
+    fn severity_by_label() {
+        assert_eq!(
+            severity_for_labels(&["critical".into()]),
+            Severity::Critical
+        );
+        assert_eq!(severity_for_labels(&["bug".into()]), Severity::Major);
+        assert_eq!(severity_for_labels(&["minor".into()]), Severity::Minor);
+        assert_eq!(severity_for_labels(&[]), Severity::Minor);
+    }
+
+    #[test]
+    fn age_days_computes_correctly() {
+        assert_eq!(age_days("2026-04-01T00:00:00Z", "2026-04-20T00:00:00Z"), 19);
+        assert_eq!(age_days("bad", "2026-04-20"), 0);
+    }
+
+    #[test]
+    fn parse_issues_accepts_both_shapes() {
+        let arr = r#"[{"number":1,"title":"x","body":"y","url":"u","state":"open","labels":[],"created_at":"2026-04-20T00:00:00Z"}]"#;
+        let v = parse_issues_json(arr).unwrap();
+        assert_eq!(v.len(), 1);
+
+        let obj = r#"{"issues":[{"number":2,"title":"y","body":"z","url":"u","state":"closed","labels":[],"created_at":"2026-04-20T00:00:00Z"}]}"#;
+        let v = parse_issues_json(obj).unwrap();
+        assert_eq!(v.len(), 1);
+    }
+
+    #[test]
+    fn path_matches_support_is_boundary_safe() {
+        assert!(path_matches_support(
+            "src/auth/token.rs",
+            &["src/auth/".into()]
+        ));
+        assert!(!path_matches_support(
+            "src/auth_helpers/x.rs",
+            &["src/auth".into()]
+        ));
+    }
+}

--- a/crates/specere/src/main.rs
+++ b/crates/specere/src/main.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 
+mod bug_tracker;
 mod evaluate;
 mod harness;
 mod smells;
@@ -338,6 +339,31 @@ enum ObserveKind {
         #[arg(long, default_value = "table")]
         format: String,
     },
+    /// Poll a bug-tracker (GitHub or Gitea) and emit one
+    /// `bug_reported` event per actionable issue. FR-EQ-010..013.
+    WatchIssues {
+        /// Issue-tracker provider.
+        #[arg(long, default_value = "github")]
+        provider: String,
+        /// Repository identifier `owner/name`. Required unless
+        /// `--from-fixture` is given.
+        #[arg(long)]
+        repo: Option<String>,
+        /// Test-only — read a canned JSON response from this file
+        /// instead of calling the live API.
+        #[arg(long, value_name = "PATH", hide = true)]
+        from_fixture: Option<PathBuf>,
+        /// Polling interval seconds (reserved for the future daemon mode;
+        /// `--once` ignores this value).
+        #[arg(long, default_value_t = 600)]
+        interval: u64,
+        /// One-shot: fetch-and-exit. Default behaviour today.
+        #[arg(long, default_value_t = true)]
+        once: bool,
+        /// Reserved for future daemon mode; currently errors out.
+        #[arg(long, default_value_t = false)]
+        daemon: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -433,6 +459,22 @@ fn main() -> Result<()> {
                 limit,
                 format,
             } => run_observe_query(&ctx, since, signal, source, limit, &format),
+            ObserveKind::WatchIssues {
+                provider,
+                repo,
+                from_fixture,
+                interval,
+                once,
+                daemon,
+            } => bug_tracker::run_watch_issues(
+                &ctx,
+                &provider,
+                repo,
+                from_fixture,
+                interval,
+                once,
+                daemon,
+            ),
         },
         Command::Serve {
             config,
@@ -879,6 +921,7 @@ fn compute_per_spec_calibrations_with_clusters(
             _ => {}
         }
     }
+    let bug_pressure = aggregate_bug_pressure(events);
 
     // Per-spec cluster flakiness = mean of flakiness_scores across every
     // harness node whose path is a member of any support entry for that
@@ -896,7 +939,11 @@ fn compute_per_spec_calibrations_with_clusters(
             c as f64 / (c + m) as f64
         };
         let n_smells = smells.get(&spec.id).map(|s| s.len()).unwrap_or(0) as f64;
-        let smell_penalty = (1.0 - 0.15 * n_smells).clamp(0.3, 1.0);
+        let base_smell_penalty = (1.0 - 0.15 * n_smells).clamp(0.3, 1.0);
+        // FR-EQ-012: bug pressure compresses smell_penalty further. A
+        // single critical bug yields ≈0.30 pressure → multiplier 0.70.
+        let bug_mult = 1.0 - bug_pressure.get(&spec.id).copied().unwrap_or(0.0);
+        let smell_penalty = (base_smell_penalty * bug_mult).clamp(0.3, 1.0);
 
         // Find harness nodes whose path starts with any of this spec's
         // support prefixes. Reuse the same directory-boundary semantics
@@ -971,6 +1018,8 @@ fn compute_per_spec_calibrations(
             _ => {}
         }
     }
+    // FR-EQ-012 bug-signal aggregation shared with the cluster-aware path.
+    let bug_pressure = aggregate_bug_pressure(events);
 
     let mut out: std::collections::HashMap<String, specere_filter::Calibration> =
         std::collections::HashMap::new();
@@ -984,13 +1033,51 @@ fn compute_per_spec_calibrations(
             c as f64 / (c + m) as f64
         };
         let n_smells = smells.get(&spec.id).map(|s| s.len()).unwrap_or(0) as f64;
-        let smell_penalty = (1.0 - 0.15 * n_smells).clamp(0.3, 1.0);
+        let base_smell_penalty = (1.0 - 0.15 * n_smells).clamp(0.3, 1.0);
+        let bug_mult = 1.0 - bug_pressure.get(&spec.id).copied().unwrap_or(0.0);
+        let smell_penalty = (base_smell_penalty * bug_mult).clamp(0.3, 1.0);
         out.insert(
             spec.id.clone(),
             specere_filter::Calibration::from_evidence(kill_rate, smell_penalty),
         );
     }
     out
+}
+
+/// FR-EQ-012 — aggregate `bug_reported` events per spec into a single
+/// saturating pressure value in `[0, 1]`. Used by both the cluster-aware
+/// and non-cluster calibration paths.
+fn aggregate_bug_pressure(
+    events: &[specere_telemetry::Event],
+) -> std::collections::HashMap<String, f64> {
+    use std::collections::HashMap;
+    let mut pressure: HashMap<String, f64> = HashMap::new();
+    for e in events {
+        if e.attrs.get("event_kind").map(String::as_str) != Some("bug_reported") {
+            continue;
+        }
+        let Some(sid) = e.attrs.get("spec_id").map(String::as_str) else {
+            continue;
+        };
+        if sid == "unknown" {
+            continue;
+        }
+        let severity = e
+            .attrs
+            .get("severity")
+            .map(String::as_str)
+            .unwrap_or("minor");
+        let state = e.attrs.get("state").map(String::as_str).unwrap_or("open");
+        let age = e
+            .attrs
+            .get("age_days")
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or(0);
+        let signal = specere_filter::Calibration::bug_signal_decayed(severity, state, age);
+        let entry = pressure.entry(sid.to_string()).or_insert(0.0);
+        *entry = 1.0 - (1.0 - *entry) * (1.0 - signal);
+    }
+    pressure
 }
 
 /// Thin enum so `run_filter_run` can dispatch to HMM, BP, or RBPF

--- a/crates/specere/tests/fr_eq_010_watch_issues.rs
+++ b/crates/specere/tests/fr_eq_010_watch_issues.rs
@@ -1,0 +1,169 @@
+//! FR-EQ-010..013 — `specere observe watch-issues` + bug_reported events
+//! in the filter calibration path.
+
+mod common;
+
+use common::TempRepo;
+
+fn seed_sensor_map(repo: &TempRepo) {
+    repo.write(
+        ".specere/sensor-map.toml",
+        r#"
+schema_version = 1
+
+[specs]
+"FR-auth"    = { support = ["src/auth/"] }
+"FR-billing" = { support = ["src/billing/"] }
+"#,
+    );
+}
+
+const FIXTURE: &str = r#"[
+  {
+    "number": 101,
+    "title": "login fails under load",
+    "body": "trace shows `src/auth/token.rs:42` panicking on empty JWT",
+    "url": "https://github.com/x/y/issues/101",
+    "state": "open",
+    "labels": [{"name": "critical"}],
+    "created_at": "2026-04-10T10:00:00Z"
+  },
+  {
+    "number": 102,
+    "title": "typo in README",
+    "body": "README.md says 'the the'",
+    "url": "https://github.com/x/y/issues/102",
+    "state": "open",
+    "labels": [{"name": "docs"}],
+    "created_at": "2026-04-15T00:00:00Z"
+  },
+  {
+    "number": 103,
+    "title": "billing off-by-one",
+    "body": "src/billing/charge.rs computes wrong amount",
+    "url": "https://github.com/x/y/issues/103",
+    "state": "closed",
+    "labels": [{"name": "bug"}],
+    "created_at": "2026-04-05T00:00:00Z",
+    "pull_request": {"url": "pr/1"}
+  }
+]"#;
+
+#[test]
+fn watch_issues_emits_one_event_per_actionable_issue() {
+    let repo = TempRepo::new();
+    seed_sensor_map(&repo);
+    let fixture_path = repo.abs(".specere/issues-fixture.json");
+    std::fs::create_dir_all(fixture_path.parent().unwrap()).unwrap();
+    std::fs::write(&fixture_path, FIXTURE).unwrap();
+
+    let out = repo
+        .run_specere(&[
+            "observe",
+            "watch-issues",
+            "--provider",
+            "github",
+            "--from-fixture",
+            fixture_path.to_str().unwrap(),
+            "--once",
+        ])
+        .output()
+        .expect("spawn");
+    assert!(
+        out.status.success(),
+        "watch-issues failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("2 bug_reported event(s) emitted"),
+        "expected 2 emitted (101 + 103 — 102 is docs-labelled); got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("1 skipped"),
+        "expected 1 skipped (docs label); got:\n{stdout}"
+    );
+
+    let events_raw = std::fs::read_to_string(repo.abs(".specere/events.jsonl")).unwrap();
+    let lines: Vec<_> = events_raw.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 2, "two events: {events_raw}");
+
+    // Find the FR-auth event (critical, open, triaged from body path).
+    let auth = lines
+        .iter()
+        .find(|l| l.contains("FR-auth"))
+        .expect("FR-auth event present");
+    let v: serde_json::Value = serde_json::from_str(auth).unwrap();
+    assert_eq!(v["attrs"]["event_kind"].as_str(), Some("bug_reported"));
+    assert_eq!(v["attrs"]["severity"].as_str(), Some("critical"));
+    assert_eq!(v["attrs"]["state"].as_str(), Some("open"));
+    assert_eq!(v["attrs"]["issue_number"].as_str(), Some("101"));
+}
+
+#[test]
+fn bug_reported_events_reduce_filter_calibration_quality() {
+    // A spec receives 10 mutation_result caught events (kill_rate = 1.0)
+    // AND one critical bug_reported event. The per-spec quality should
+    // drop below 1.0 because the bug signal compresses smell_penalty.
+    let repo = TempRepo::new();
+    seed_sensor_map(&repo);
+    // 10 caught mutations → kill_rate 1.0.
+    let mut events = String::new();
+    for i in 0..10 {
+        events.push_str(&format!(
+            r#"{{"ts":"2026-04-20T10:00:{:02}.000Z","source":"t","signal":"traces","attrs":{{"event_kind":"mutation_result","spec_id":"FR-auth","outcome":"caught"}}}}{}"#,
+            i, "\n"
+        ));
+    }
+    // One critical bug, 5 days old.
+    events.push_str(
+        r#"{"ts":"2026-04-20T11:00:00.000Z","source":"t","signal":"traces","attrs":{"event_kind":"bug_reported","spec_id":"FR-auth","severity":"critical","state":"open","age_days":"5"}}
+"#,
+    );
+    // At least one test_outcome so filter run processes something.
+    events.push_str(
+        r#"{"ts":"2026-04-20T12:00:00.000Z","source":"t","signal":"traces","attrs":{"event_kind":"test_outcome","spec_id":"FR-auth","outcome":"pass"}}
+"#,
+    );
+    std::fs::write(repo.abs(".specere/events.jsonl"), events).unwrap();
+
+    let out = repo
+        .run_specere(&["filter", "run"])
+        .output()
+        .expect("spawn");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // The calibration-summary block prints per-spec `q=…` when any spec
+    // deviates from prototype. With a bug signal, FR-auth's q MUST be
+    // < 1.0.
+    assert!(
+        stdout.contains("FR-auth") && stdout.contains("q=0."),
+        "expected FR-auth's quality below 1.0 due to bug_reported event; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn watch_issues_handles_empty_fixture() {
+    let repo = TempRepo::new();
+    seed_sensor_map(&repo);
+    let fixture = repo.abs(".specere/empty.json");
+    std::fs::create_dir_all(fixture.parent().unwrap()).unwrap();
+    std::fs::write(&fixture, "[]").unwrap();
+    let out = repo
+        .run_specere(&[
+            "observe",
+            "watch-issues",
+            "--provider",
+            "github",
+            "--from-fixture",
+            fixture.to_str().unwrap(),
+            "--once",
+        ])
+        .output()
+        .expect("spawn");
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("0 bug_reported event(s)"));
+}

--- a/docs/evidence-quality-plan.md
+++ b/docs/evidence-quality-plan.md
@@ -11,7 +11,7 @@
 | Release | Slice | Scope | FRs | Status |
 |---|---|---|---|---|
 | **v1.0.5** | Mutation-calibrated sensors + test-smell detector + motion-matrix-fit + suspicious-SAT review queue | ~900 LoC, no external APIs or paid services | FR-EQ-001 … FR-EQ-007 | ✅ **Landed on main** |
-| **v1.0.6** | Bug-tracker bridge (GitHub + Gitea) | ~600 LoC, requires credentials, light LLM spend for triage (embeddings) | FR-EQ-010 … FR-EQ-013 | ⏸ Deferred pending user direction |
+| **v1.0.6** | Bug-tracker bridge (GitHub + Gitea) | ~600 LoC, requires credentials, heuristic-only triage (LLM reranking deferred) | FR-EQ-010 … FR-EQ-013 | ✅ **Landed on main** (watch-issues + bug_reported decay; cursor + LLM triage deferred to follow-ups) |
 | **v1.1.0** | LLM adversary agent with hard $20/mo budget | ~800 LoC + ongoing LLM spend | FR-EQ-020 … FR-EQ-024 | ⏸ Deferred pending user direction |
 | **v1.2.0+** | Harness manager + inspector (new proposal) | ~1200 LoC for slices S1–S3 | FR-HM-NNN (not yet numbered) | 📝 Proposal under review (PR #93) |
 


### PR DESCRIPTION
## Summary

Closes #77 (v1.0.6 tracker) + #78 (FR-EQ-010) + #79 (FR-EQ-011) + #80 (FR-EQ-012) + #81 (FR-EQ-013).

### What ships

- New CLI: \`specere observe watch-issues --provider github|gitea --repo owner/name [--once|--from-fixture <path>]\`.
- Parses GitHub + Gitea issue JSON (same shape for the subset we consume).
- Filters out \`question\`/\`docs\`/\`duplicate\`/\`not-planned\` labels and closed-without-linked-PR issues.
- **Heuristic triage** against each spec's \`support\` set (directory-boundary-safe). LLM reranking deferred — \`min_confidence\` in \`[triage]\` section of sensor-map controls when we fall back to \`spec_id = "unknown"\`.
- **Severity from labels**: \`critical\`/\`blocker\`/\`p0\` → critical; \`bug\`/\`regression\`/\`p1\` → major; else minor.
- One \`bug_reported\` event per actionable issue with rich attrs.
- Fixture-backed via hidden \`--from-fixture\` for CI. Live HTTP requires \`GITHUB_TOKEN\` or \`GITEA_TOKEN\`.

### Filter-calibration integration (FR-EQ-012)

- New \`Calibration::bug_signal_decayed(severity, state, age_days)\`:
  \`\`\`
  base = critical:0.30 / major:0.15 / minor:0.05
  half_life = open:50d / closed:25d
  signal = base × exp(-ln(2) · age / half_life)
  \`\`\`
  (Kim '07 empirical half-lives.)
- Shared \`aggregate_bug_pressure\` helper stacks multiple bugs per spec saturatingly: \`pressure = 1 − Π(1 − signal)\`.
- Both calibration paths (plain \`compute_per_spec_calibrations\` + cluster-aware \`..._with_clusters\`) compress \`smell_penalty\` by \`(1 − pressure)\`.
- **Back-compat**: bit-identical when no \`bug_reported\` events exist.

### What's deferred (follow-up slice v1.0.6b)

- **FR-EQ-011 LLM triage**: embedding + rerank. Current heuristic is path-token scan only. Tracked in issue comments.
- **FR-EQ-013 multi-source cursors**: \`[cursors]\` table in posterior.toml. Legacy single cursor still works; bug-tracker runs are idempotent at the event-store level anyway.

## Test plan

- [x] **9 unit tests** (\`bug_tracker::tests\`): triage-by-path-reference, below-confidence returns None, actionable filters (skip labels, closed-without-PR, keep closed-with-PR), severity-by-label, age_days math, JSON parser for both shapes, path-boundary safety.
- [x] **3 integration tests**: watch-issues emits N events from fixture + skips docs-labelled; bug_reported reduces filter-calibration quality; empty fixture yields zero events.
- [x] **390 workspace tests** pass.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`cargo fmt --all --check\` clean.